### PR TITLE
Added BenchmarkHprose

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -12,8 +12,56 @@ import (
 	"time"
 
 	"github.com/hashicorp/net-rpc-msgpackrpc"
+	hproserpc "github.com/hprose/hprose-golang/rpc"
 	"github.com/smallnest/rpcx/codec"
 )
+
+func mul(a, b int) int {
+	return a * b
+}
+
+// RO is Reomote object
+type RO struct {
+	Mul func(a, b int) (int, error)
+}
+
+func benchmarkHproseClient(client *hproserpc.TCPClient, b *testing.B) {
+	// Synchronous calls
+	var ro *RO
+	client.UseService(&ro)
+	procs := runtime.GOMAXPROCS(-1)
+	N := int32(b.N)
+	var wg sync.WaitGroup
+	wg.Add(procs)
+	b.StartTimer()
+	for p := 0; p < procs; p++ {
+		go func() {
+			for atomic.AddInt32(&N, -1) >= 0 {
+				reply, err := ro.Mul(7, 8)
+				if err != nil {
+					b.Fatalf("rpc error: Mul: expected no error but got string %q", err.Error())
+				}
+				if reply != 7*8 {
+					b.Fatalf("rpc error: Mul: expected %d got %d", reply, 7*8)
+				}
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	b.StopTimer()
+}
+
+func BenchmarkHprose(b *testing.B) {
+	b.StopTimer()
+	server := hproserpc.NewTCPServer("")
+	server.AddFunction("mul", mul, hproserpc.Options{Simple: true})
+	server.Handle()
+	client := hproserpc.NewTCPClient(server.URI())
+	defer server.Close()
+	defer client.Close()
+	benchmarkHproseClient(client, b)
+}
 
 func listenTCP() (net.Listener, string) {
 	l, e := net.Listen("tcp", "127.0.0.1:0") // any available address


### PR DESCRIPTION
```
BenchmarkHprose-8           	  200000	     10650 ns/op	     746 B/op	      22 allocs/op
BenchmarkNetRPC_gob-8       	  100000	     14736 ns/op	     320 B/op	       9 allocs/op
BenchmarkNetRPC_jsonrpc-8   	  100000	     15375 ns/op	    1170 B/op	      31 allocs/op
BenchmarkNetRPC_msgp-8      	  100000	     14825 ns/op	     776 B/op	      35 allocs/op
BenchmarkRPCX_gob-8         	  100000	     15103 ns/op	     371 B/op	      11 allocs/op
BenchmarkRPCX_json-8        	  100000	     15492 ns/op	    1219 B/op	      33 allocs/op
BenchmarkRPCX_msgp-8        	  100000	     14758 ns/op	     826 B/op	      37 allocs/op
BenchmarkRPCX_gencodec-8    	  100000	     14588 ns/op	    4531 B/op	      19 allocs/op
BenchmarkRPCX_protobuf-8    	  100000	     14208 ns/op	     779 B/op	      15 allocs/op
PASS
ok  	github.com/smallnest/rpcx	115.452s
```