### PR TITLE
Added benchmarks for hprose 2.0

### DIFF
--- a/_benchmarks/hprose_client.go
+++ b/_benchmarks/hprose_client.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"reflect"
+	"runtime/pprof"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/hprose/hprose-golang/rpc"
+	"github.com/montanaflynn/stats"
+)
+
+var concurrency = flag.Int("c", 1, "concurrency")
+var total = flag.Int("n", 1, "total requests for all clients")
+var host = flag.String("s", "127.0.0.1:8972", "server ip and port")
+var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to file")
+
+type RO struct {
+	Say func(args []byte) (reply []byte, err error) `simple:"true"`
+}
+
+func main() {
+	flag.Parse()
+
+	if *cpuprofile != "" {
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
+
+	n := *concurrency
+	m := *total / n
+
+	fmt.Printf("concurrency: %d\nrequests per client: %d\n\n", n, m)
+
+	args := prepareArgs()
+
+	b, _ := args.Marshal()
+	fmt.Printf("message size: %d bytes\n\n", len(b))
+
+	var wg sync.WaitGroup
+	wg.Add(n * m)
+
+	var startWg sync.WaitGroup
+	startWg.Add(n)
+
+	var trans uint64
+	var transOK uint64
+
+	d := make([][]int64, n, n)
+	var ro *RO
+	client := rpc.NewTCPClient("tcp://" + *host)
+	client.SetMaxPoolSize(n)
+	client.UseService(&ro)
+
+	//it contains warmup time but we can ignore it
+	totalT := time.Now().UnixNano()
+	for i := 0; i < n; i++ {
+		dt := make([]int64, 0, m)
+		d = append(d, dt)
+
+		go func(i int) {
+			reply := &BenchmarkMessage{}
+
+			//warmup
+			ro.Say(b)
+
+			startWg.Done()
+			startWg.Wait()
+			fmt.Printf("goroutine %d started\n", i)
+
+			for j := 0; j < m; j++ {
+				t := time.Now().UnixNano()
+				a, _ := args.Marshal()
+				r, err := ro.Say(a)
+				reply.Unmarshal(r)
+				t = time.Now().UnixNano() - t
+
+				d[i] = append(d[i], t)
+
+				if err == nil && reply.Field1 == "OK" {
+					atomic.AddUint64(&transOK, 1)
+				}
+
+				if err != nil {
+					fmt.Println(err.Error())
+				}
+
+				atomic.AddUint64(&trans, 1)
+				wg.Done()
+			}
+
+		}(i)
+
+	}
+
+	wg.Wait()
+	client.Close()
+	totalT = time.Now().UnixNano() - totalT
+	totalT = totalT / 1000000
+	fmt.Printf("took %d ms for %d requests", totalT, n*m)
+
+	totalD := make([]int64, 0, n*m)
+	for _, k := range d {
+		totalD = append(totalD, k...)
+	}
+	totalD2 := make([]float64, 0, n*m)
+	for _, k := range totalD {
+		totalD2 = append(totalD2, float64(k))
+	}
+
+	mean, _ := stats.Mean(totalD2)
+	median, _ := stats.Median(totalD2)
+	max, _ := stats.Max(totalD2)
+	min, _ := stats.Min(totalD2)
+	p99, _ := stats.Percentile(totalD2, 99.9)
+
+	fmt.Printf("sent     requests    : %d\n", n*m)
+	fmt.Printf("received requests    : %d\n", atomic.LoadUint64(&trans))
+	fmt.Printf("received requests_OK : %d\n", atomic.LoadUint64(&transOK))
+	fmt.Printf("throughput  (TPS)    : %d\n", int64(n*m)*1000/totalT)
+	fmt.Printf("mean: %.f ns, median: %.f ns, max: %.f ns, min: %.f ns, p99.9: %.f ns\n", mean, median, max, min, p99)
+	fmt.Printf("mean: %d ms, median: %d ms, max: %d ms, min: %d ms, p99: %d ms\n", int64(mean/1000000), int64(median/1000000), int64(max/1000000), int64(min/1000000), int64(p99/1000000))
+
+}
+
+func prepareArgs() *BenchmarkMessage {
+	b := true
+	var i int32 = 100000
+	var s = "许多往事在眼前一幕一幕，变的那麼模糊"
+
+	var args BenchmarkMessage
+
+	v := reflect.ValueOf(&args).Elem()
+	num := v.NumField()
+	for k := 0; k < num; k++ {
+		field := v.Field(k)
+		if field.Type().Kind() == reflect.Ptr {
+			switch v.Field(k).Type().Elem().Kind() {
+			case reflect.Int, reflect.Int32, reflect.Int64:
+				field.Set(reflect.ValueOf(&i))
+			case reflect.Bool:
+				field.Set(reflect.ValueOf(&b))
+			case reflect.String:
+				field.Set(reflect.ValueOf(&s))
+			}
+		} else {
+			switch field.Kind() {
+			case reflect.Int, reflect.Int32, reflect.Int64:
+				field.SetInt(100000)
+			case reflect.Bool:
+				field.SetBool(true)
+			case reflect.String:
+				field.SetString(s)
+			}
+		}
+
+	}
+	return &args
+}

--- a/_benchmarks/hprose_mclient.go
+++ b/_benchmarks/hprose_mclient.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/hprose/hprose-golang/rpc"
+	"github.com/montanaflynn/stats"
+)
+
+var concurrency = flag.Int("c", 1, "concurrency")
+var total = flag.Int("n", 1, "total requests for all clients")
+var host = flag.String("s", "127.0.0.1:8972", "server ip and port")
+
+type RO struct {
+	Say func(args []byte) (reply []byte, err error) `simple:"true"`
+}
+
+func main() {
+	flag.Parse()
+	n := *concurrency
+	m := *total / n
+
+	servers := strings.Split(*host, ",")
+	for i, server := range servers {
+		servers[i] = "tcp://" + server
+	}
+
+	fmt.Printf("Servers: %+v\n\n", servers)
+
+	fmt.Printf("concurrency: %d\nrequests per client: %d\n\n", n, m)
+
+	args := prepareArgs()
+
+	b, _ := args.Marshal()
+	fmt.Printf("message size: %d bytes\n\n", len(b))
+
+	var wg sync.WaitGroup
+	wg.Add(n * m)
+
+	var startWg sync.WaitGroup
+	startWg.Add(n)
+
+	var trans uint64
+	var transOK uint64
+
+	d := make([][]int64, n, n)
+	var ro *RO
+	client := rpc.NewTCPClient(servers...)
+	client.SetMaxPoolSize(n)
+	client.UseService(&ro)
+
+	//it contains warmup time but we can ignore it
+	totalT := time.Now().UnixNano()
+	for i := 0; i < n; i++ {
+		dt := make([]int64, 0, m)
+		d = append(d, dt)
+
+		go func(i int) {
+			reply := &BenchmarkMessage{}
+
+			//warmup
+			ro.Say(b)
+
+			startWg.Done()
+			startWg.Wait()
+
+			fmt.Printf("goroutine %d started\n", i)
+
+			for j := 0; j < m; j++ {
+				t := time.Now().UnixNano()
+				a, _ := args.Marshal()
+				r, err := ro.Say(a)
+				reply.Unmarshal(r)
+				t = time.Now().UnixNano() - t
+
+				d[i] = append(d[i], t)
+
+				if err == nil && reply.Field1 == "OK" {
+					atomic.AddUint64(&transOK, 1)
+				}
+
+				atomic.AddUint64(&trans, 1)
+				wg.Done()
+			}
+		}(i)
+
+	}
+
+	wg.Wait()
+	client.Close()
+	totalT = time.Now().UnixNano() - totalT
+	totalT = totalT / 1000000
+	fmt.Printf("took %d ms for %d requests", totalT, n*m)
+
+	totalD := make([]int64, 0, n*m)
+	for _, k := range d {
+		totalD = append(totalD, k...)
+	}
+	totalD2 := make([]float64, 0, n*m)
+	for _, k := range totalD {
+		totalD2 = append(totalD2, float64(k))
+	}
+
+	mean, _ := stats.Mean(totalD2)
+	median, _ := stats.Median(totalD2)
+	max, _ := stats.Max(totalD2)
+	min, _ := stats.Min(totalD2)
+	p99, _ := stats.Percentile(totalD2, 99.9)
+
+	fmt.Printf("sent     requests    : %d\n", n*m)
+	fmt.Printf("received requests    : %d\n", atomic.LoadUint64(&trans))
+	fmt.Printf("received requests_OK : %d\n", atomic.LoadUint64(&transOK))
+	fmt.Printf("throughput  (TPS)    : %d\n", int64(n*m)*1000/totalT)
+	fmt.Printf("mean: %.f ns, median: %.f ns, max: %.f ns, min: %.f ns, p99: %.f ns\n", mean, median, max, min, p99)
+	fmt.Printf("mean: %d ms, median: %d ms, max: %d ms, min: %d ms, p99: %d ms\n", int64(mean/1000000), int64(median/1000000), int64(max/1000000), int64(min/1000000), int64(p99/1000000))
+
+}
+
+func prepareArgs() *BenchmarkMessage {
+	b := true
+	var i int32 = 100000
+	var s = "许多往事在眼前一幕一幕，变的那麼模糊"
+
+	var args BenchmarkMessage
+
+	v := reflect.ValueOf(&args).Elem()
+	num := v.NumField()
+	for k := 0; k < num; k++ {
+		field := v.Field(k)
+		if field.Type().Kind() == reflect.Ptr {
+			switch v.Field(k).Type().Elem().Kind() {
+			case reflect.Int, reflect.Int32, reflect.Int64:
+				field.Set(reflect.ValueOf(&i))
+			case reflect.Bool:
+				field.Set(reflect.ValueOf(&b))
+			case reflect.String:
+				field.Set(reflect.ValueOf(&s))
+			}
+		} else {
+			switch field.Kind() {
+			case reflect.Int, reflect.Int32, reflect.Int64:
+				field.SetInt(100000)
+			case reflect.Bool:
+				field.SetBool(true)
+			case reflect.String:
+				field.SetString(s)
+			}
+		}
+
+	}
+	return &args
+}

--- a/_benchmarks/hprose_server.go
+++ b/_benchmarks/hprose_server.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/hprose/hprose-golang/rpc"
+)
+
+func say(in []byte) ([]byte, error) {
+	args := &BenchmarkMessage{}
+	args.Unmarshal(in)
+	args.Field1 = "OK"
+	args.Field2 = 100
+	return args.Marshal()
+}
+
+var host = flag.String("s", "127.0.0.1:8972", "listened ip and port")
+
+func main() {
+	flag.Parse()
+	server := rpc.NewTCPServer("tcp://" + *host)
+	server.AddFunction("say", say, rpc.Options{Simple: true})
+	server.Start()
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/net-rpc-msgpackrpc"
+	hproserpc "github.com/hprose/hprose-golang/rpc"
 	"github.com/smallnest/rpcx/codec"
 )
 
@@ -21,6 +22,53 @@ func listenTCP() (net.Listener, string) {
 		log.Fatalf("net.Listen tcp :0: %v", e)
 	}
 	return l, l.Addr().String()
+}
+
+func mul(a, b int) int {
+	return a * b
+}
+
+// RO is Reomote object
+type RO struct {
+	Mul func(a, b int) (int, error) `simple:"true"`
+}
+
+func benchmarkHproseClient(client *hproserpc.TCPClient, b *testing.B) {
+	// Synchronous calls
+	var ro *RO
+	client.UseService(&ro)
+	procs := runtime.GOMAXPROCS(-1)
+	N := int32(b.N)
+	var wg sync.WaitGroup
+	wg.Add(procs)
+	b.StartTimer()
+	for p := 0; p < procs; p++ {
+		go func() {
+			for atomic.AddInt32(&N, -1) >= 0 {
+				reply, err := ro.Mul(7, 8)
+				if err != nil {
+					b.Fatalf("rpc error: Mul: expected no error but got string %q", err.Error())
+				}
+				if reply != 7*8 {
+					b.Fatalf("rpc error: Mul: expected %d got %d", reply, 7*8)
+				}
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	b.StopTimer()
+}
+
+func BenchmarkHprose(b *testing.B) {
+	b.StopTimer()
+	server := hproserpc.NewTCPServer("")
+	server.AddFunction("mul", mul, hproserpc.Options{Simple: true})
+	server.Handle()
+	client := hproserpc.NewTCPClient(server.URI())
+	defer server.Close()
+	defer client.Close()
+	benchmarkHproseClient(client, b)
 }
 
 func benchmarkClient(client *rpc.Client, b *testing.B) {


### PR DESCRIPTION
因为 hprose 不支持直接使用 protobuf 编码。所以在这个测试程序是手动 protobuf 编解码（这个操作也加入了计时中），传输是通过 hprose rpc 传输的，相当于做了两次序列化和反序列化（protobuf 序列化 + hprose 序列化）。不过速度还是很快。

另外，因为 hprose 客户端是线程安全的，并且内置连接池，所以客户端测试程序中，我只创建了一个客户端，设置了并发连接数。而没有每个 goroutine 创建一个客户端。