### PR TITLE
Update hprose 2.0 benchmark

### DIFF
--- a/_benchmarks/hprose_mclient.go
+++ b/_benchmarks/hprose_mclient.go
@@ -50,10 +50,6 @@ func main() {
 	var transOK uint64
 
 	d := make([][]int64, n, n)
-	var ro *RO
-	client := rpc.NewTCPClient(servers...)
-	client.SetMaxPoolSize(n)
-	client.UseService(&ro)
 
 	//it contains warmup time but we can ignore it
 	totalT := time.Now().UnixNano()
@@ -62,6 +58,9 @@ func main() {
 		d = append(d, dt)
 
 		go func(i int) {
+			var ro *RO
+			client := rpc.NewTCPClient(servers...)
+			client.UseService(&ro)
 			reply := &BenchmarkMessage{}
 
 			//warmup
@@ -88,12 +87,12 @@ func main() {
 				atomic.AddUint64(&trans, 1)
 				wg.Done()
 			}
+			client.Close()
 		}(i)
 
 	}
 
 	wg.Wait()
-	client.Close()
 	totalT = time.Now().UnixNano() - totalT
 	totalT = totalT / 1000000
 	fmt.Printf("took %d ms for %d requests", totalT, n*m)

--- a/_benchmarks/hprose_server.go
+++ b/_benchmarks/hprose_server.go
@@ -17,7 +17,6 @@ func say(in []byte) ([]byte, error) {
 var host = flag.String("s", "127.0.0.1:8972", "listened ip and port")
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	flag.Parse()
 	server := rpc.NewTCPServer("tcp://" + *host)
 	server.ErrorDelay = 0

--- a/_benchmarks/hprose_server.go
+++ b/_benchmarks/hprose_server.go
@@ -17,8 +17,10 @@ func say(in []byte) ([]byte, error) {
 var host = flag.String("s", "127.0.0.1:8972", "listened ip and port")
 
 func main() {
+	runtime.GOMAXPROCS(runtime.NumCPU())
 	flag.Parse()
 	server := rpc.NewTCPServer("tcp://" + *host)
+	server.ErrorDelay = 0
 	server.AddFunction("say", say, rpc.Options{Simple: true})
 	server.Start()
 }


### PR DESCRIPTION
把一个客户端改为每个 goroutine 一个客户端。

服务器端增加了
```go
server.ErrorDelay = 0
```

发生错误时不在延时，目的是出错时尽快返回错误。

同时 hprose-golang 也更新了，原来性能在高并发下降低还有个原因是数据发送缓冲池的锁竞争造成的。现在性能应该有所提升。我在

* iMac (Retina 5K, 27-inch, Late 2015)
* CPU：4 GHz Intel Core i7
* 内存：32 GB 1867 MHz DDR3

下测试（客户端和服务器同机）的结果如下：

### rpcx
concurrent clients|mean(ms)|median(ms)|max(ms)|min(ms)|p99.9|throughput(TPS)
-------------|-------------|-------------|-------------|-------------|------------|-------------
100|1|1|20|0|2|82074
200|2|2|20|0|4|80231
500|6|6|19|0|15|73637
1000|13|13|42|2|26|71321
2000|28|27|94|20|66|69468
5000|72|70|550|38|216|65832

### hprose-go 2.0
concurrent clients|mean(ms)|median(ms)|max(ms)|min(ms)|p99.9|throughput(TPS)
-------------|-------------|-------------|-------------|-------------|------------|-------------
100|1|1|12|0|3|83104
200|2|2|17|0|6|80282
500|6|6|28|0|14|72275
1000|14|13|56|0|27|69633
2000|29|28|82|0|57|66524
5000|79|78|246|0|182|60543
