### PR TITLE
Fixed: etcd_selector error

### DIFF
--- a/clientselector/etcd_selector.go
+++ b/clientselector/etcd_selector.go
@@ -117,6 +117,11 @@ func (s *EtcdClientSelector) watch() {
 		//services are changed, we pull service again instead of processing single node
 		if res.Action == "expire" {
 			s.pullServers()
+			if !res.Node.Dir {
+				// clientAndServer delete the invalid client connection
+				removedServer := strings.TrimPrefix(res.Node.Key, s.BasePath+"/")
+				delete(s.clientAndServer, removedServer)
+			}
 		} else if res.Action == "set" || res.Action == "update" {
 			s.pullServers()
 		} else if res.Action == "delete" {
@@ -160,6 +165,9 @@ func (s *EtcdClientSelector) pullServers() {
 			if s.len > 0 {
 				s.currentServer = s.currentServer % s.len
 			}
+		} else {
+			// when the last instance is down, it should be deleted
+			s.clientAndServer = map[string]*rpc.Client{}
 		}
 
 	}

--- a/clientselector/etcd_selector.go
+++ b/clientselector/etcd_selector.go
@@ -192,7 +192,7 @@ func (s *EtcdClientSelector) createWeighted(nodes client.Nodes) {
 
 			if w != "" {
 				weight, err := strconv.Atoi(w)
-				if err != nil {
+				if err == nil {
 					s.WeightedServers[i].Weight = weight
 					s.WeightedServers[i].EffectiveWeight = weight
 				}


### PR DESCRIPTION
两种情况：
1. 提供相同服务的server1和server2，当server1和server2都挂掉后，最后挂掉的实例不会被删除。
2. 提供相同服务的server1和server2，首先，server1挂掉后，server2正常；然后当server1在etcd ttl expire后，这个实例没有从clientAndServer中删除，server1重启后，因老连接没有删除，所以新连接无效