### PR TITLE
improve code quality &&  remove service name from Unregister method

### DIFF
--- a/clientselector/etcd_selector.go
+++ b/clientselector/etcd_selector.go
@@ -2,6 +2,7 @@ package clientselector
 
 import (
 	"errors"
+	"log"
 	"math/rand"
 	"net"
 	"net/rpc"
@@ -72,7 +73,10 @@ func (s *EtcdClientSelector) AllClients(clientCodecFunc rpcx.ClientCodecFunc) []
 	for _, sv := range s.Servers {
 		ss := strings.Split(sv, "@")
 		c, err := rpcx.NewDirectRPCClient(s.Client, clientCodecFunc, ss[0], ss[1], s.dailTimeout)
-		if err == nil {
+		if err != nil {
+			log.Fatal("rpc client connect server failed. " + err.Error())
+			continue
+		} else {
 			clients = append(clients, c)
 		}
 	}
@@ -88,6 +92,7 @@ func (s *EtcdClientSelector) start() {
 	})
 
 	if err != nil {
+		log.Fatal("etcd new client failed. " + err.Error())
 		return
 	}
 	s.KeysAPI = client.NewKeysAPI(cli)

--- a/plugin/etcd_register.go
+++ b/plugin/etcd_register.go
@@ -130,7 +130,7 @@ func (plugin *EtcdRegisterPlugin) forceMkdirs(path string) (err error) {
 	}
 	_, err = plugin.KeysAPI.Set(context.TODO(), path, "",
 		&client.SetOptions{
-			PrevExist: client.PrevIgnore,
+			PrevExist: client.PrevExist,
 			Dir:       true,
 		})
 
@@ -145,7 +145,8 @@ func (plugin *EtcdRegisterPlugin) Register(name string, rcvr interface{}, metada
 		return
 	}
 	nodePath := fmt.Sprintf("%s/%s", plugin.BasePath, name)
-	if err = plugin.mkdirs(nodePath); err != nil {
+	if err = plugin.forceMkdirs(nodePath); err != nil {
+		log.Fatal(err.Error())
 		return
 	}
 

--- a/plugin/zookeeper_register.go
+++ b/plugin/zookeeper_register.go
@@ -175,6 +175,21 @@ func (plugin *ZooKeeperRegisterPlugin) Unregister(name string) (err error) {
 			log.Printf("delete: ok\n")
 		}
 	}
+
+	// because plugin.Start() method will be executed by timer continuously
+	// so it need to remove the service name from service list
+	if plugin.Services == nil || len(plugin.Services) <= 0 {
+		return nil
+	}
+	var index int = 0
+	for index = 0; index < len(plugin.Services); index++ {
+		if plugin.Services[index] == name {
+			break
+		}
+	}
+	if index != len(plugin.Services) {
+		plugin.Services = append(plugin.Services[:index], plugin.Services[index+1:]...)
+	}
 	return
 }
 


### PR DESCRIPTION
1.增加少量的错误处理；
2.在rpc服务注销的过程中，增加了从services列表中移除服务名的操作逻辑，因为plugin.Start()一直在定时做services列表的beatheart，如果不删除，注销过程则不生效。