### PR TITLE
Modify init []Services num=0

### DIFF
--- a/_examples/etcd_registry/server.go
+++ b/_examples/etcd_registry/server.go
@@ -42,7 +42,7 @@ func main() {
 		EtcdServers:    []string{*e},
 		BasePath:       "/rpcx",
 		Metrics:        metrics.NewRegistry(),
-		Services:       make([]string, 1),
+		Services:       make([]string, 0),
 		UpdateInterval: time.Minute,
 	}
 	rplugin.Start()

--- a/_examples/zookeeper_registry/server.go
+++ b/_examples/zookeeper_registry/server.go
@@ -38,7 +38,7 @@ func main() {
 		ZooKeeperServers: []string{*zk},
 		BasePath:         "/rpcx",
 		Metrics:          metrics.NewRegistry(),
-		Services:         make([]string, 1),
+		Services:         make([]string, 0),
 		UpdateInterval:   10 * time.Second,
 	}
 	rplugin.Start()

--- a/plugin/etcd_register.go
+++ b/plugin/etcd_register.go
@@ -42,10 +42,12 @@ func (plugin *EtcdRegisterPlugin) Start() (err error) {
 	})
 
 	if err != nil {
-		return err
+		log.Println("new client: " + err.Error())
+		return
 	}
 	plugin.KeysAPI = client.NewKeysAPI(cli)
-	if err = plugin.mkdirs(plugin.BasePath); err != nil {
+	if err = plugin.forceMkdirs(plugin.BasePath); err != nil {
+		log.Println(err.Error())
 		return
 	}
 
@@ -59,7 +61,7 @@ func (plugin *EtcdRegisterPlugin) Start() (err error) {
 
 				for _, name := range plugin.Services {
 					if err = plugin.mkdirs(fmt.Sprintf("%s/%s", plugin.BasePath, name)); err != nil {
-						log.Fatal(err.Error())
+						log.Println(err.Error())
 						continue
 					}
 
@@ -69,7 +71,7 @@ func (plugin *EtcdRegisterPlugin) Start() (err error) {
 						Recursive: false,
 					})
 					if err != nil {
-						log.Fatal("get etcd key failed. " + err.Error())
+						log.Println("get etcd key failed. " + err.Error())
 					} else {
 						if v, err = url.ParseQuery(resp.Node.Value); err != nil {
 							continue
@@ -82,7 +84,7 @@ func (plugin *EtcdRegisterPlugin) Start() (err error) {
 						})
 
 						if err != nil {
-							log.Fatal("set etcd key failed. " + err.Error())
+							log.Println("set etcd key failed. " + err.Error())
 						}
 					}
 


### PR DESCRIPTION
初始rpcx的服务列表时，其长度应该是0，而不是1，否则，会导致plugin.Services的列表有一个空字符串，导致服务Start(),启动会报错