### PR TITLE
fix protoc-gen-gogofaster: program not found or is not executable

### DIFF
--- a/codec/protobuf_service.proto
+++ b/codec/protobuf_service.proto
@@ -1,5 +1,6 @@
-// protoc --gogofaster_out=. protobuf_service.proto
-// mv protobuf_service.pb.go protobuf_service_test.go 
+// protoc --gofast_out=. protobuf_service.proto
+// mv protobuf_service.pb.go protobuf_service.go
+syntax = "proto3";
 package codec;
 
 


### PR DESCRIPTION
fix protoc-gen-gogofaster: program not found or is not executable  

and change proto2 to proto3