### PR TITLE
reset rpcClient to nil when Call failed

### DIFF
--- a/client.go
+++ b/client.go
@@ -111,6 +111,7 @@ func (s *DirectClientSelector) AllClients(clientCodecFunc ClientCodecFunc) []*rp
 
 func (s *DirectClientSelector) HandleFailedClient(client *rpc.Client) {
 	client.Close()
+	s.rpcClient = nil // reset
 }
 
 // ClientCodecFunc is used to create a rpc.ClientCodecFunc from net.Conn.


### PR DESCRIPTION
rpcClient 调用失败后，DirectClientSelector 的 HandleFailedClient 方法如果只是关闭而没有置空的话，
会导致后续的调用一直失败，因为 Select 到仍然是之前被关闭掉的那个 rpcClient 。

```go
//Select returns a rpc client.
func (s *DirectClientSelector) Select(clientCodecFunc ClientCodecFunc, options ...interface{}) (*rpc.Client, error) {
	if s.rpcClient != nil {
		return s.rpcClient, nil
	}
	c, err := NewDirectRPCClient(s.Client, clientCodecFunc, s.Network, s.Address, s.DialTimeout)
	s.rpcClient = c
	return c, err
}
```