### PR TITLE
add TestKcpServe, demonstrate and enable kcp based rcp with encryption.

### DIFF
--- a/kcpserver_test.go
+++ b/kcpserver_test.go
@@ -1,0 +1,81 @@
+package rpcx
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cryrand "crypto/rand"
+	"crypto/sha1"
+	kcp "github.com/xtaci/kcp-go"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+var kcpServerAddr string
+var kcpServer *Server
+
+var pass = []byte("testpass")
+var salt []byte = CryptoRandBytes(64)
+
+// at 1 million iter, takes about 1.5 seconds to generate the key.
+// That's a good production value. For test we do much less, only 1024.
+//const iter = 1 << 20
+const iter = 1 << 10
+const keylen = 32
+
+var key = pbkdf2.Key(pass, salt, iter, keylen, sha1.New)
+
+func CryptoRandBytes(n int) []byte {
+	b := make([]byte, n)
+	_, err := cryrand.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func startKcpServer() {
+	blockCrypt, err := kcp.NewSalsa20BlockCrypt(key)
+	panicOn(err)
+
+	kcpServer = NewServer()
+	kcpServer.KCPConfig.BlockCrypt = blockCrypt
+	kcpServer.RegisterName(serviceName, service)
+	kcpServer.Start("kcp", "127.0.0.1:0")
+	kcpServerAddr = kcpServer.Address()
+}
+
+func startKcpClient(t *testing.T) {
+
+	blockCrypt, err := kcp.NewSalsa20BlockCrypt(key)
+	panicOn(err)
+	s := &DirectClientSelector{Network: "kcp", Address: kcpServerAddr, DialTimeout: 10 * time.Second}
+	client := NewClient(s)
+	client.Block = blockCrypt
+	defer client.Close()
+
+	args := &Args{7, 8}
+	var reply Reply
+
+	divCall := client.Go(context.Background(), serviceMethodName, args, &reply, nil)
+	replyCall := <-divCall.Done // will be equal to divCall
+	if replyCall.Error != nil {
+		t.Errorf("error for Arith: %d*%d, %v \n", args.A, args.B, replyCall.Error)
+	} else {
+		t.Logf("Arith: %d*%d=%d \n", args.A, args.B, reply.C)
+	}
+}
+
+func TestKcpServe(t *testing.T) {
+	startKcpServer()
+
+	// Give the server a moment to begin listening on that udp port.
+	time.Sleep(10 * time.Millisecond)
+	startKcpClient(t)
+}
+
+func panicOn(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -13,6 +13,7 @@ import (
 	msgpackrpc2 "github.com/rpcx-ecosystem/net-rpc-msgpackrpc2"
 	"github.com/smallnest/rpcx/core"
 	"github.com/smallnest/rpcx/log"
+	kcp "github.com/xtaci/kcp-go"
 )
 
 const (
@@ -135,6 +136,11 @@ type Server struct {
 	Timeout      time.Duration
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
+	KCPConfig    KCPConfig
+}
+
+type KCPConfig struct {
+	BlockCrypt kcp.BlockCrypt
 }
 
 // NewServer returns a new Server.
@@ -150,7 +156,7 @@ func NewServer() *Server {
 var defaultServer = NewServer()
 
 // Serve starts and listens RPC requests.
-//It is blocked until receiving connectings from clients.
+// It is blocked until receiving connectings from clients.
 func Serve(n, address string) (err error) {
 	return defaultServer.Serve(n, address)
 }
@@ -226,10 +232,10 @@ func validIP4(ipAddress string) bool {
 }
 
 // Serve starts and listens RPC requests.
-//It is blocked until receiving connectings from clients.
+// It is blocked until receiving connectings from clients.
 func (s *Server) Serve(network, address string) (err error) {
 	var ln net.Listener
-	ln, err = makeListener(network, address)
+	ln, err = makeListener(network, address, s.KCPConfig.BlockCrypt)
 	if err != nil {
 		return
 	}
@@ -352,7 +358,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // Start starts and listens RPC requests without blocking.
 func (s *Server) Start(network, address string) (err error) {
 	var ln net.Listener
-	ln, err = makeListener(network, address)
+	ln, err = makeListener(network, address, s.KCPConfig.BlockCrypt)
 
 	if err != nil {
 		log.Errorf("failed to start server: %v", err)

--- a/server_unix.go
+++ b/server_unix.go
@@ -9,10 +9,11 @@ import (
 	kcp "github.com/xtaci/kcp-go"
 )
 
-func makeListener(network, address string) (ln net.Listener, err error) {
+// block can be nil if the caller wishes to skip encryption.
+func makeListener(network, address string, block kcp.BlockCrypt) (ln net.Listener, err error) {
 	switch network {
 	case "kcp":
-		ln, err = kcp.ListenWithOptions(address, nil, 10, 3)
+		ln, err = kcp.ListenWithOptions(address, block, 10, 3)
 	case "reuseport":
 		if validIP4(address) {
 			network = "tcp4"

--- a/server_windows.go
+++ b/server_windows.go
@@ -8,10 +8,11 @@ import (
 	kcp "github.com/xtaci/kcp-go"
 )
 
-func makeListener(network, address string) (ln net.Listener, err error) {
+// block can be nil if the caller wishes to skip encryption.
+func makeListener(network, address string, block kcp.BlockCrypt) (ln net.Listener, err error) {
 	switch network {
 	case "kcp":
-		ln, err = kcp.ListenWithOptions(address, nil, 10, 3)
+		ln, err = kcp.ListenWithOptions(address, block, 10, 3)
 	case "reuseport":
 		if validIP4(address) {
 			network = "tcp4"


### PR DESCRIPTION
Add TestKcpServe; Demonstrate and enable encrypted rpc using kcp.

**Please answer these questions before sending pull requests. Thanks!**

### did you run tests in local？
Yes.

If there's a better way to add encryption for kcp based transport, let me know.