### PR TITLE
关于服务端向客户端发送消息的调整

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -491,13 +491,13 @@ func (client *Client) send(ctx context.Context, call *Call) {
 
 func (client *Client) input() {
 	var err error
-	var res = protocol.NewMessage()
+	//var res = protocol.NewMessage()
 
 	for err == nil {
 		if client.option.ReadTimeout != 0 {
 			client.Conn.SetReadDeadline(time.Now().Add(client.option.ReadTimeout))
 		}
-
+		res := protocol.NewMessage()
 		err = res.Decode(client.r)
 		//res, err = protocol.Read(client.r)
 

--- a/server/server.go
+++ b/server/server.go
@@ -137,6 +137,14 @@ func (s *Server) SendMessage(conn net.Conn, servicePath, serviceMethod string, m
 	return err
 }
 
+func (s *Server) GetAllConn() []net.Conn{} {
+	var result []net.Conn
+	for clientConn, _ := range s.activeConn{
+		result=append(result,clientConn)
+	}
+        return result
+}
+
 func (s *Server) getDoneChan() <-chan struct{} {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
client/client.go  修正    func (client *Client) input()   的一个致命bug
server/server.go增加 一个快速获取当前活动连接的方法