### PR TITLE
fix jsonrpc2 http server error

### DIFF
--- a/server/jsonrpc2.go
+++ b/server/jsonrpc2.go
@@ -97,6 +97,7 @@ func writeResponse(w http.ResponseWriter, res *jsonrpcRespone) {
 }
 
 func (s *Server) startJSONRPC2(ln net.Listener) {
-	http.HandleFunc("/", s.jsonrpcHandler)
-	go http.Serve(ln, nil)
+	newServer := http.NewServeMux()
+	newServer.HandleFunc("/", s.jsonrpcHandler)
+	go http.Serve(ln, newServer)
 }


### PR DESCRIPTION
修复startJSONRPC2 中的http server配置中的bug，该bug会导致https://github.com/rpcx-ecosystem/rpcx-examples3/selector下使用tcp协议的example单机多端口server启动失败