### PR TITLE
chore: rename param rune to ch

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -46,8 +46,8 @@ type service struct {
 }
 
 func isExported(name string) bool {
-	rune, _ := utf8.DecodeRuneInString(name)
-	return unicode.IsUpper(rune)
+	ch, _ := utf8.DecodeRuneInString(name)
+	return unicode.IsUpper(ch)
 }
 
 func isExportedOrBuiltinType(t reflect.Type) bool {


### PR DESCRIPTION
rune is the keyword of golang itself; so rename the param rune to ch;
reference: https://github.com/golang/go/blob/02e492f1a33033d88c2c307262a56e578939fc60/src/go/token/token.go#L317