### PR TITLE
r.RemoteAddr is string not net.Conn

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -55,6 +55,8 @@ var (
 	StartSendRequestContextKey = &contextKey{"start-send-request"}
 	// TagContextKey is used to record extra info in handling services. Its value is a map[string]interface{}
 	TagContextKey = &contextKey{"service-tag"}
+	// HttpConnContextKey is used to store http connection.
+	HttpConnContextKey = &contextKey{"http-conn"}
 )
 
 // Server is rpcx server that use TCP or UDP.


### PR DESCRIPTION
jsonrpc 调用服务时发现, ctx无法获得底层conn对象.  发现jsonrpc里 RemoteConnContextKey 存的是string.
用ConnContext 修改Request的context.