### PR TITLE
JSONRPC 支持服务路径带点号

### DIFF
--- a/server/jsonrpc2.go
+++ b/server/jsonrpc2.go
@@ -65,16 +65,16 @@ func (s *Server) handleJSONRPCRequest(ctx context.Context, r *jsonrpcRequest, he
 	req.SetMessageType(protocol.Request)
 	req.SetSerializeType(protocol.JSON)
 
-	pathAndMethod := strings.SplitN(r.Method, ".", 2)
-	if len(pathAndMethod) != 2 {
+	pathAndMethod := strings.Split(r.Method, ".")
+	if len(pathAndMethod) < 2 {
 		res.Error = &JSONRPCError{
 			Code:    CodeMethodNotFound,
 			Message: "must contains servicepath and method",
 		}
 		return res
 	}
-	req.ServicePath = pathAndMethod[0]
-	req.ServiceMethod = pathAndMethod[1]
+	req.ServicePath = strings.Join(pathAndMethod[:len(pathAndMethod)-1], ".")
+	req.ServiceMethod = pathAndMethod[len(pathAndMethod)-1]
 	req.Payload = *r.Params
 
 	// meta


### PR DESCRIPTION
目前服务名称带.的会被分割失败 

比如
a.b为服务名, c 为方法名
a.b.c 目前会被分割成  a b.c

由于方法名不能带.，所以应该分割成  服务名为 a.b，方法名为c