### PR TITLE
fix: fix the method name of the client plugin implementation

### DIFF
--- a/client/opencensus.go
+++ b/client/opencensus.go
@@ -9,7 +9,7 @@ import (
 
 type OpenCensusPlugin struct{}
 
-func (p *OpenCensusPlugin) DoPreCall(ctx context.Context, servicePath, serviceMethod string, args interface{}) error {
+func (p *OpenCensusPlugin) PreCall(ctx context.Context, servicePath, serviceMethod string, args interface{}) error {
 	var span1 *trace.Span
 
 	// if it is called in rpc service in case that a service calls antoher service,
@@ -33,7 +33,7 @@ func (p *OpenCensusPlugin) DoPreCall(ctx context.Context, servicePath, serviceMe
 	}
 	return nil
 }
-func (p *OpenCensusPlugin) DoPostCall(ctx context.Context, servicePath, serviceMethod string, args interface{}, reply interface{}, err error) error {
+func (p *OpenCensusPlugin) PostCall(ctx context.Context, servicePath, serviceMethod string, args interface{}, reply interface{}, err error) error {
 	if rpcxContext, ok := ctx.(*share.Context); ok {
 		span1 := rpcxContext.Value(share.OpencensusSpanClientKey)
 		if span1 != nil {

--- a/client/opentracing.go
+++ b/client/opentracing.go
@@ -10,7 +10,7 @@ import (
 
 type OpenTracingPlugin struct{}
 
-func (p *OpenTracingPlugin) DoPreCall(ctx context.Context, servicePath, serviceMethod string, args interface{}) error {
+func (p *OpenTracingPlugin) PreCall(ctx context.Context, servicePath, serviceMethod string, args interface{}) error {
 	var span1 opentracing.Span
 
 	// if it is called in rpc service in case that a service calls antoher service,
@@ -36,7 +36,7 @@ func (p *OpenTracingPlugin) DoPreCall(ctx context.Context, servicePath, serviceM
 	}
 	return nil
 }
-func (p *OpenTracingPlugin) DoPostCall(ctx context.Context, servicePath, serviceMethod string, args interface{}, reply interface{}, err error) error {
+func (p *OpenTracingPlugin) PostCall(ctx context.Context, servicePath, serviceMethod string, args interface{}, reply interface{}, err error) error {
 	if rpcxContext, ok := ctx.(*share.Context); ok {
 		span1 := rpcxContext.Value(share.OpentracingSpanClientKey)
 		if span1 != nil {


### PR DESCRIPTION
修改两个client plugin implementation的method name，与plugin interface保持一致。

其实个人觉得DoPre...、DoPost...这种形式更好，跟PluginContainer保持一致。