### PR TITLE
add server heartbeat plugin

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -34,6 +34,8 @@ type PluginContainer interface {
 
 	DoPreWriteRequest(ctx context.Context) error
 	DoPostWriteRequest(ctx context.Context, r *protocol.Message, e error) error
+
+	DoHeartbeatRequest(ctx context.Context, req *protocol.Message) error
 }
 
 // Plugin is the server plugin interface.
@@ -105,6 +107,11 @@ type (
 	//PostWriteRequestPlugin represents .
 	PostWriteRequestPlugin interface {
 		PostWriteRequest(ctx context.Context, r *protocol.Message, e error) error
+	}
+
+	// HeartbeatPlugin is .
+	HeartbeatPlugin interface {
+		OnHeartbeat(ctx context.Context, req *protocol.Message) error
 	}
 )
 
@@ -340,6 +347,20 @@ func (p *pluginContainer) DoPostWriteRequest(ctx context.Context, r *protocol.Me
 	for i := range p.plugins {
 		if plugin, ok := p.plugins[i].(PostWriteRequestPlugin); ok {
 			err := plugin.PostWriteRequest(ctx, r, e)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// DoHeartbeatRequest invokes HeartbeatRequest plugin.
+func (p *pluginContainer) DoHeartbeatRequest(ctx context.Context, r *protocol.Message) error {
+	for i := range p.plugins {
+		if plugin, ok := p.plugins[i].(HeartbeatPlugin); ok {
+			err := plugin.OnHeartbeat(ctx, r)
 			if err != nil {
 				return err
 			}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -111,7 +111,7 @@ type (
 
 	// HeartbeatPlugin is .
 	HeartbeatPlugin interface {
-		OnHeartbeat(ctx context.Context, req *protocol.Message) error
+		HeartbeatRequest(ctx context.Context, req *protocol.Message) error
 	}
 )
 
@@ -360,7 +360,7 @@ func (p *pluginContainer) DoPostWriteRequest(ctx context.Context, r *protocol.Me
 func (p *pluginContainer) DoHeartbeatRequest(ctx context.Context, r *protocol.Message) error {
 	for i := range p.plugins {
 		if plugin, ok := p.plugins[i].(HeartbeatPlugin); ok {
-			err := plugin.OnHeartbeat(ctx, r)
+			err := plugin.HeartbeatRequest(ctx, r)
 			if err != nil {
 				return err
 			}

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -12,7 +12,7 @@ import (
 
 type HeartbeatHandler struct{}
 
-func (h *HeartbeatHandler) OnHeartbeat(ctx context.Context, req *protocol.Message) error {
+func (h *HeartbeatHandler) HeartbeatRequest(ctx context.Context, req *protocol.Message) error {
 	conn := ctx.Value(RemoteConnContextKey).(net.Conn)
 	println("OnHeartbeat:", conn.RemoteAddr().String())
 	return nil
@@ -38,6 +38,8 @@ func TestPluginHeartbeat(t *testing.T) {
 		}
 	}()
 	go func() {
+		// wait for server start complete
+		time.Sleep(time.Second)
 		defer wg.Done()
 		// client
 		opts := client.DefaultOption

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"context"
+	"github.com/smallnest/rpcx/client"
+	"github.com/smallnest/rpcx/protocol"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+type HeartbeatHandler struct{}
+
+func (h *HeartbeatHandler) OnHeartbeat(ctx context.Context, req *protocol.Message) error {
+	conn := ctx.Value(RemoteConnContextKey).(net.Conn)
+	println("OnHeartbeat:", conn.RemoteAddr().String())
+	return nil
+}
+
+// TestPluginHeartbeat: go test -v -test.run TestPluginHeartbeat
+func TestPluginHeartbeat(t *testing.T) {
+	h := &HeartbeatHandler{}
+	s := NewServer(
+		WithReadTimeout(time.Duration(5)*time.Second),
+		WithWriteTimeout(time.Duration(5)*time.Second),
+	)
+	s.Plugins.Add(h)
+	s.RegisterName("Arith", new(Arith), "")
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		// server
+		defer wg.Done()
+		err := s.Serve("tcp", "127.0.0.1:9001")
+		if err != nil {
+			t.Log(err.Error())
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		// client
+		opts := client.DefaultOption
+		opts.Heartbeat = true
+		opts.HeartbeatInterval = time.Second
+		opts.ReadTimeout = time.Duration(5) * time.Second
+		opts.WriteTimeout = time.Duration(5) * time.Second
+		opts.ConnectTimeout = time.Duration(5) * time.Second
+		// PeerDiscovery
+		d := client.NewPeer2PeerDiscovery("tcp@127.0.0.1:9001", "")
+		c := client.NewXClient("Arith", client.Failtry, client.RoundRobin, d, opts)
+		i := 0
+		for {
+			i++
+			resp := &Reply{}
+			c.Call(context.Background(), "Mul", &Args{A: 1, B: 5}, resp)
+			t.Log("call Mul resp:", resp.C)
+			time.Sleep(time.Second)
+			if i > 10 {
+				break
+			}
+		}
+		c.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		s.Shutdown(ctx)
+	}()
+	wg.Wait()
+}

--- a/server/server.go
+++ b/server/server.go
@@ -405,6 +405,7 @@ func (s *Server) serveConn(conn net.Conn) {
 			defer atomic.AddInt32(&s.handlerMsgNum, -1)
 
 			if req.IsHeartbeat() {
+				s.Plugins.DoHeartbeatRequest(ctx, req)
 				req.SetMessageType(protocol.Response)
 				data := req.EncodeSlicePointer()
 				conn.Write(*data)


### PR DESCRIPTION
目前服务端对客户端发起的 heartbeat 请求是直接丢弃，某些业务场景需要针对心跳来做一些特定处理；

因此希望能通过 HeartbeatPlugin 接口，可以实现 OnHeartbeat 的自定义处理。

单元测试：
```
go test -v -test.run TestPluginHeartbeat
```

如有需要改动，烦请告知。

以上，谢谢！