### PR TITLE
add ErrKeyNotFound exception in NewConsulDiscoveryStore

### DIFF
--- a/client/consul_discovery.go
+++ b/client/consul_discovery.go
@@ -56,7 +56,7 @@ func NewConsulDiscoveryStore(basePath string, kv store.Store) ServiceDiscovery {
 	d.stopCh = make(chan struct{})
 
 	ps, err := kv.List(basePath)
-	if err != nil {
+	if err != nil && err.Error() != store.ErrKeyNotFound.Error() {
 		log.Infof("cannot get services of from registry: %v, err: %v", basePath, err)
 		panic(err)
 	}


### PR DESCRIPTION
调用NewConsulDiscoveryStore时，如果key不存在，可以先不panic