### PR TITLE
Remove "err != io.EOF"

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -688,7 +688,7 @@ func (client *Client) input() {
 
 	client.mutex.Unlock()
 
-	if err != nil && err != io.EOF && !closing {
+	if err != nil && !closing {
 		log.Error("rpcx: client protocol error:", err)
 	}
 }


### PR DESCRIPTION
"if err != nil && err != io.EOF && !closing" changed to "if err != nil && !closing", because "err != io.EOF" never here