### PR TITLE
修正在gateway中, 如果业务方法返回错误信息，无法调用DoPreWriteResponse和DoPostWriteResponse中…

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -172,6 +172,8 @@ func (s *Server) handleGatewayRequest(w http.ResponseWriter, r *http.Request, pa
 	defer protocol.FreeMsg(res)
 
 	if err != nil {
+		// call DoPreWriteResponse
+		s.Plugins.DoPreWriteResponse(ctx, req, nil, err)
 		if s.HandleServiceError != nil {
 			s.HandleServiceError(err)
 		} else {
@@ -180,6 +182,8 @@ func (s *Server) handleGatewayRequest(w http.ResponseWriter, r *http.Request, pa
 		wh.Set(XMessageStatusType, "Error")
 		wh.Set(XErrorMessage, err.Error())
 		w.WriteHeader(500)
+		// call DoPostWriteResponse
+		s.Plugins.DoPostWriteResponse(ctx, req, req.Clone(), err)
 		return
 	}
 


### PR DESCRIPTION
修正在gateway中, 如果业务方法返回错误信息，无法调用DoPreWriteResponse和DoPostWriteResponse中间件的bug。

修正文件
\rpcx\server\gateway.go 174-188 行