### PR TITLE
gateway中的DoPreWriteResponse调用处理，context增加DeleteKey方法

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -35,6 +35,15 @@ func (ctx *Context) SetValue(key, val interface{}) {
 	ctx.ctx.SetValue(key, val)
 }
 
+// DeleteKey delete the kv pair by key.
+func (ctx *Context) DeleteKey(key interface{}) {
+	if ctx.ctx==nil || key == nil{
+		return
+	}
+	ctx.ctx.DeleteKey(key)
+}
+
+
 // Payload returns the  payload.
 func (ctx *Context) Payload() []byte {
 	return ctx.req.Payload

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -187,7 +187,8 @@ func (s *Server) handleGatewayRequest(w http.ResponseWriter, r *http.Request, pa
 		return
 	}
 
-	s.Plugins.DoPreWriteResponse(newCtx, req, nil, nil)
+	// will set res to call
+	s.Plugins.DoPreWriteResponse(newCtx, req, res, nil)
 	if len(resMetadata) > 0 { // copy meta in context to request
 		meta := res.Metadata
 		if meta == nil {

--- a/share/context.go
+++ b/share/context.go
@@ -43,6 +43,14 @@ func (c *Context) SetValue(key, val interface{}) {
 	c.tags[key] = val
 }
 
+// DeleteKey delete the kv pair by key.
+func (c *Context) DeleteKey(key interface{}) {
+	if c.tags == nil || key == nil{
+		return
+	}
+	delete(c.tags, key)
+}
+
 func (c *Context) String() string {
 	return fmt.Sprintf("%v.WithValue(%v)", c.Context, c.tags)
 }


### PR DESCRIPTION
1,在gateway中, 如果服务方法执行成功, 则调用DoPreWriteResponse插件时，应当带上res结果参数
2,context增加DeleteKey方法, 以方便处理在PreCall、PreWriteResponse等中间件时, 为了处理业务逻辑而临时附加的值，使用后方便删除。