### PR TITLE
perform nil check before conn init

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -82,7 +82,12 @@ func newDirectConn(c *Client, network, address string) (net.Conn, error) {
 	var tlsConn *tls.Conn
 	var err error
 
-	if c != nil && c.option.TLSConfig != nil {
+	if c == nil {
+		err = fmt.Errorf("nil client")
+		return nil, err
+	}
+
+	if c.option.TLSConfig != nil {
 		dialer := &net.Dialer{
 			Timeout: c.option.ConnectTimeout,
 		}


### PR DESCRIPTION
Hi @smallnest, I have found that func `newDirectConn` only performs nil check in the first branch, so if the client is `nil` and TLS connection is not enabled, it will lead to a panic instead of an error.

So, I think it's better to perform the nil check first and avoid panic by returning an error.