### PR TITLE
Fix blocking on serverplugin.Stop()

### DIFF
--- a/serverplugin/consul.go
+++ b/serverplugin/consul.go
@@ -56,6 +56,7 @@ func (p *ConsulRegisterPlugin) Start() error {
 		kv, err := libkv.NewStore(store.CONSUL, p.ConsulServers, p.Options)
 		if err != nil {
 			log.Errorf("cannot create consul registry: %v", err)
+			close(p.done)
 			return err
 		}
 		p.kv = kv
@@ -68,6 +69,7 @@ func (p *ConsulRegisterPlugin) Start() error {
 	err := p.kv.Put(p.BasePath, []byte("rpcx_path"), &store.WriteOptions{IsDir: true})
 	if err != nil {
 		log.Errorf("cannot create consul path %s: %v", p.BasePath, err)
+		close(p.done)
 		return err
 	}
 

--- a/serverplugin/redis.go
+++ b/serverplugin/redis.go
@@ -56,6 +56,7 @@ func (p *RedisRegisterPlugin) Start() error {
 		kv, err := libkv.NewStore(store.REDIS, p.RedisServers, p.Options)
 		if err != nil {
 			log.Errorf("cannot create redis registry: %v", err)
+			close(p.done)
 			return err
 		}
 		p.kv = kv
@@ -64,6 +65,7 @@ func (p *RedisRegisterPlugin) Start() error {
 	err := p.kv.Put(p.BasePath, []byte("rpcx_path"), &store.WriteOptions{IsDir: true})
 	if err != nil && !strings.Contains(err.Error(), "Not a file") {
 		log.Errorf("cannot create redis path %s: %v", p.BasePath, err)
+		close(p.done)
 		return err
 	}
 

--- a/serverplugin/zookeeper.go
+++ b/serverplugin/zookeeper.go
@@ -57,6 +57,7 @@ func (p *ZooKeeperRegisterPlugin) Start() error {
 		kv, err := libkv.NewStore(store.ZK, p.ZooKeeperServers, p.Options)
 		if err != nil {
 			log.Errorf("cannot create zk registry: %v", err)
+			close(p.done)
 			return err
 		}
 		p.kv = kv
@@ -69,6 +70,7 @@ func (p *ZooKeeperRegisterPlugin) Start() error {
 	err := p.kv.Put(p.BasePath, []byte("rpcx_path"), &store.WriteOptions{IsDir: true})
 	if err != nil {
 		log.Errorf("cannot create zk path %s: %v", p.BasePath, err)
+		close(p.done)
 		return err
 	}
 


### PR DESCRIPTION
`plugin.Start()` return when `libkv` error, keeping `p.done` still open.
If plugin.Stop() after that, program will block forever on `<-p.done` because
no one close it.

Fix this by always close `p.done` when `plugin.Start()` return error.