### PR TITLE
Optimize Unzip() by avoiding an unnecessary memory copy

### DIFF
--- a/util/compress.go
+++ b/util/compress.go
@@ -27,22 +27,13 @@ func init() {
 
 // Unzip unzips data.
 func Unzip(data []byte) ([]byte, error) {
-	buf := spBuffer.Get().(*bytes.Buffer)
-	defer func() {
-		buf.Reset()
-		spBuffer.Put(buf)
-	}()
-
-	_, err := buf.Write(data)
-	if err != nil {
-		return nil, err
-	}
+	buf := bytes.NewBuffer(data)
 
 	gr := spReader.Get().(*gzip.Reader)
 	defer func() {
 		spReader.Put(gr)
 	}()
-	err = gr.Reset(buf)
+	err := gr.Reset(buf)
 	if err != nil {
 		return nil, err
 	}

--- a/util/compress_test.go
+++ b/util/compress_test.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
 	"testing"
 )
 
@@ -45,6 +48,53 @@ func BenchmarkUnzip(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			s2, err := Unzip(data)
+			if err != nil {
+				b.Errorf("failed to zip: %v", err)
+			}
+			_ = s2
+		}
+	})
+}
+
+func oldUnzip(data []byte) ([]byte, error) {
+	buf := spBuffer.Get().(*bytes.Buffer)
+	defer func() {
+		buf.Reset()
+		spBuffer.Put(buf)
+	}()
+
+	_, err := buf.Write(data)
+	if err != nil {
+		return nil, err
+	}
+
+	gr := spReader.Get().(*gzip.Reader)
+	defer func() {
+		spReader.Put(gr)
+	}()
+	err = gr.Reset(buf)
+	if err != nil {
+		return nil, err
+	}
+	defer gr.Close()
+
+	data, err = ioutil.ReadAll(gr)
+	if err != nil {
+		return nil, err
+	}
+	return data, err
+}
+
+func BenchmarkUnzip_Old(b *testing.B) {
+	s := "%5B%7B%22service%22%3A%22AttrDict%22%2C%22service_address%22%3A%22udp%40127.0.0.1%3A5353%22%7D%2C%7B%22service%22%3A%22BrasInfo%22%2C%22service_address%22%3A%22udp%40127.0.0.1%3A5353%22%7D%5D"
+	data, err := Zip([]byte(s))
+	if err != nil {
+		b.Fatalf("failed to zip: %v", err)
+	}
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			s2, err := oldUnzip(data)
 			if err != nil {
 				b.Errorf("failed to zip: %v", err)
 			}

--- a/util/net.go
+++ b/util/net.go
@@ -18,13 +18,7 @@ func GetFreePort() (port int, err error) {
 	}
 	defer listener.Close()
 
-	addr := listener.Addr().String()
-	_, portString, err := net.SplitHostPort(addr)
-	if err != nil {
-		return 0, err
-	}
-
-	return strconv.Atoi(portString)
+	return listener.Addr().(*net.TCPAddr).Port, nil
 }
 
 // ParseRpcxAddress parses rpcx address such as tcp@127.0.0.1:8972  quic@192.168.1.1:9981

--- a/util/net_test.go
+++ b/util/net_test.go
@@ -1,6 +1,51 @@
 package util
 
-import "testing"
+import (
+	"net"
+	"strconv"
+	"testing"
+)
+
+func TestGetFreePort(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		port, err := GetFreePort()
+		if err != nil {
+			t.Error(err)
+		}
+
+		if port == 0 {
+			t.Error("GetFreePort() return 0")
+		}
+	}
+}
+
+var oldGetFreePort = func() (port int, err error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer listener.Close()
+
+	addr := listener.Addr().String()
+	_, portString, err := net.SplitHostPort(addr)
+	if err != nil {
+		return 0, err
+	}
+
+	return strconv.Atoi(portString)
+}
+
+func BenchmarkGetFreePort_Old(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		oldGetFreePort()
+	}
+}
+
+func BenchmarkGetFreePort_New(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		GetFreePort()
+	}
+}
 
 func TestExternalIPV4(t *testing.T) {
 	ip, err := ExternalIPV4()


### PR DESCRIPTION
`buf.Write(data)` create a slice and copy `data` into. Use
`bytes.NewBuffer(data)` to avoid this.

    go test -bench="BenchmarkUnzip*" ./util
    
    goos: linux
    goarch: amd64
    pkg: github.com/smallnest/rpcx/util
    cpu: Intel(R) Core(TM) i7-7500U CPU @ 2.70GHz
    BenchmarkUnzip-4         1235281               968.5 ns/op
    BenchmarkUnzip_Old-4     1000000              1052 ns/op
    PASS
    ok      github.com/smallnest/rpcx/util  3.260s

