### PR TITLE
fix scope override of err

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -190,9 +190,9 @@ func newDirectWSConn(c *Client, network, address string) (net.Conn, error) {
 	}
 
 	if c.option.TLSConfig != nil {
-		config, err := websocket.NewConfig(url, origin)
-		if err != nil {
-			return nil, err
+		config, erri := websocket.NewConfig(url, origin)
+		if erri != nil {
+			return nil, erri
 		}
 		config.TlsConfig = c.option.TLSConfig
 		conn, err = websocket.DialConfig(config)


### PR DESCRIPTION
The second `err`:
	conn, err = websocket.DialConfig(config)
has the scope inside `if` statement because it the ':=' at the start of `if` block:
	config, err := websocket.NewConfig(url, origin)
So the second assignment to `err`, will discard, and return the empty not-assign
`err`.

Use a tmp var `tmpi` to avoid this.