### PR TITLE
fix: OneClientPool指针接受者

### DIFF
--- a/client/oneclient_pool.go
+++ b/client/oneclient_pool.go
@@ -60,10 +60,10 @@ func NewBidirectionalOneClientPool(count int, failMode FailMode, selectMode Sele
 }
 
 // Auth sets s token for Authentication.
-func (c *OneClientPool) Auth(auth string) {
-	c.auth = auth
+func (p *OneClientPool) Auth(auth string) {
+	p.auth = auth
 
-	for _, v := range c.oneclients {
+	for _, v := range p.oneclients {
 		v.Auth(auth)
 	}
 }
@@ -79,7 +79,7 @@ func (p *OneClientPool) Get() *OneClient {
 
 // Close this pool.
 // Please make sure it won't be used any more.
-func (p OneClientPool) Close() {
+func (p *OneClientPool) Close() {
 	for _, c := range p.oneclients {
 		c.Close()
 	}


### PR DESCRIPTION
保持指针接受者和名称统一