### PR TITLE
set default logger level to error, and give controll method

### DIFF
--- a/log/default_logger.go
+++ b/log/default_logger.go
@@ -2,55 +2,110 @@ package log
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/fatih/color"
 )
 
+// The default logger output at level error, to turn everything on like this:
+// 	export RPCX_LOG_LEVEL=99
+
+// type of log level
+type Level int
+
+// log level constant
+const (
+	LvPanic Level = iota
+	LvFatal
+	LvError
+	LvWarn
+	LvInfo
+	LvDebug
+
+	LvMax
+)
+
+type outputFn func(calldepth int, s string) error
+
+func dropOutput(calldepth int, s string) error {
+	return nil
+}
+
 type defaultLogger struct {
 	*log.Logger
+	out [LvMax]outputFn
+}
+
+func NewDefaultLogger(out io.Writer, prefix string, flag int, lv Level) *defaultLogger {
+	// set default level to error
+	level := lv
+
+	// read level from system enviroment to override
+	levelStr := os.Getenv("RPCX_LOG_LEVEL")
+	if len(levelStr) != 0 {
+		if vl, err := strconv.Atoi(levelStr); err == nil {
+			level = Level(vl)
+		}
+	}
+
+	l := &defaultLogger{}
+	l.Logger = log.New(out, prefix, flag)
+
+	for i := int(LvFatal); i < int(LvMax); i++ {
+		// always enable fatal and panic
+
+		// enable only lv <= RPCX_LOG_LEVEL
+		if i <= int(level) {
+			l.out[i] = l.Output
+		} else {
+			l.out[i] = dropOutput
+		}
+	}
+	return l
 }
 
 func (l *defaultLogger) Debug(v ...interface{}) {
-	_ = l.Output(calldepth, header("DEBUG", fmt.Sprint(v...)))
+	_ = l.out[int(LvDebug)](calldepth, header("DEBUG", fmt.Sprint(v...)))
 }
 
 func (l *defaultLogger) Debugf(format string, v ...interface{}) {
-	_ = l.Output(calldepth, header("DEBUG", fmt.Sprintf(format, v...)))
+	_ = l.out[int(LvDebug)](calldepth, header("DEBUG", fmt.Sprintf(format, v...)))
 }
 
 func (l *defaultLogger) Info(v ...interface{}) {
-	_ = l.Output(calldepth, header(color.GreenString("INFO "), fmt.Sprint(v...)))
+	_ = l.out[int(LvInfo)](calldepth, header(color.GreenString("INFO "), fmt.Sprint(v...)))
 }
 
 func (l *defaultLogger) Infof(format string, v ...interface{}) {
-	_ = l.Output(calldepth, header(color.GreenString("INFO "), fmt.Sprintf(format, v...)))
+	_ = l.out[int(LvInfo)](calldepth, header(color.GreenString("INFO "), fmt.Sprintf(format, v...)))
 }
 
 func (l *defaultLogger) Warn(v ...interface{}) {
-	_ = l.Output(calldepth, header(color.YellowString("WARN "), fmt.Sprint(v...)))
+	_ = l.out[int(LvWarn)](calldepth, header(color.YellowString("WARN "), fmt.Sprint(v...)))
 }
 
 func (l *defaultLogger) Warnf(format string, v ...interface{}) {
-	_ = l.Output(calldepth, header(color.YellowString("WARN "), fmt.Sprintf(format, v...)))
+	_ = l.out[int(LvWarn)](calldepth, header(color.YellowString("WARN "), fmt.Sprintf(format, v...)))
 }
 
 func (l *defaultLogger) Error(v ...interface{}) {
-	_ = l.Output(calldepth, header(color.RedString("ERROR"), fmt.Sprint(v...)))
+	_ = l.out[int(LvError)](calldepth, header(color.RedString("ERROR"), fmt.Sprint(v...)))
 }
 
 func (l *defaultLogger) Errorf(format string, v ...interface{}) {
-	_ = l.Output(calldepth, header(color.RedString("ERROR"), fmt.Sprintf(format, v...)))
+	_ = l.out[int(LvError)](calldepth, header(color.RedString("ERROR"), fmt.Sprintf(format, v...)))
 }
 
 func (l *defaultLogger) Fatal(v ...interface{}) {
-	_ = l.Output(calldepth, header(color.MagentaString("FATAL"), fmt.Sprint(v...)))
+	_ = l.Logger.Output(calldepth, header(color.MagentaString("FATAL"), fmt.Sprint(v...)))
 	os.Exit(1)
 }
 
 func (l *defaultLogger) Fatalf(format string, v ...interface{}) {
-	_ = l.Output(calldepth, header(color.MagentaString("FATAL"), fmt.Sprintf(format, v...)))
+	_ = l.Logger.Output(calldepth, header(color.MagentaString("FATAL"), fmt.Sprintf(format, v...)))
 	os.Exit(1)
 }
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -9,7 +9,7 @@ const (
 	calldepth = 3
 )
 
-var l Logger = &defaultLogger{log.New(os.Stdout, "", log.LstdFlags|log.Lshortfile)}
+var l Logger = NewDefaultLogger(os.Stdout, "", log.LstdFlags|log.Lshortfile, LvError)
 
 type Logger interface {
 	Debug(v ...interface{})


### PR DESCRIPTION
The output of default log are noisy, set to error default.

Give an method to controll at program startup time. To set level to info,
set enviroment like this:
    export RPCX_LOG_LEVEL=4
To turn everything on,
    export RPCX_LOG_LEVEL=99
the value of levels are:
	- lvPicni = 0
	- lvFatal = 1
	- lvError = 2
	- lvWarn = 3
	- lvInfo = 4
	- lvDebug = 5

This trick works well on my company. You may interested. If not, just ignore
and drop this pr.