### PR TITLE
fix #702, add BidirectionalBlock option to control message drop or not

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -171,7 +171,7 @@ type Option struct {
 
 	// TCPKeepAlive, if it is zero we don't set keepalive
 	TCPKeepAlivePeriod time.Duration
-	// bidirectional model, if true serverMessageChan will block to wait message for consume. default false.
+	// bidirectional mode, if true serverMessageChan will block to wait message for consume. default false.
 	BidirectionalBlock bool
 }
 


### PR DESCRIPTION
in bidirectional mode, if server produce message fast, client consume slowly from ServerMessageChan, msg will drop. add BidirectionalBlock option to control message drop or not.