### PR TITLE
close net.Listener when Stop() called

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -705,9 +705,7 @@ func (client *Client) handleServerRequest(msg *protocol.Message) {
 	serverMessageChan := client.ServerMessageChan
 	if serverMessageChan != nil {
 		if client.option.BidirectionalBlock {
-			select {
-			case serverMessageChan <- msg:
-			}
+			serverMessageChan <- msg
 		} else {
 			select {
 			case serverMessageChan <- msg:

--- a/server/file_transfer.go
+++ b/server/file_transfer.go
@@ -42,6 +42,7 @@ type FileTransfer struct {
 
 	startOnce sync.Once
 
+	ln   net.Listener
 	done chan struct{}
 }
 
@@ -128,6 +129,7 @@ func (s *FileTransfer) start() error {
 	if err != nil {
 		return err
 	}
+	s.ln = ln
 
 	var tempDelay time.Duration
 
@@ -203,6 +205,10 @@ func (s *FileTransfer) start() error {
 
 func (s *FileTransfer) Stop() error {
 	close(s.done)
+	// notify Accept() to return
+	if s.ln != nil {
+		s.ln.Close()
+	}
 
 	return nil
 }


### PR DESCRIPTION
 The start function of FileTransfer create an instance of net.Listener, but
 never close it. On that way ln.Accept() will block even s.done is closed. Then
 The Stop() function have no effect and the start() goroutine keep waiting until
 an error occur or a connection comming.

 Close s.ln on Stop() function, then Accept() will return with an error, then go
 to 'case <- s.done' line and function start() return.