### PR TITLE
Fix incorrect write timeout when s.handleRequest() taked too long

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -328,6 +328,25 @@ func (s *Server) serveByWS(ln net.Listener, rpcPath string) {
 	srv.Serve(ln)
 }
 
+func (s *Server) sendResponse(ctx *share.Context, conn net.Conn, writeCh chan *[]byte, err error, req, res *protocol.Message) {
+	if len(res.Payload) > 1024 && req.CompressType() != protocol.None {
+		res.SetCompressType(req.CompressType())
+	}
+	data := res.EncodeSlicePointer()
+	s.Plugins.DoPreWriteResponse(ctx, req, res, err)
+	if s.AsyncWrite {
+		writeCh <- data
+	} else {
+		if s.writeTimeout != 0 {
+			conn.SetWriteDeadline(time.Now().Add(s.writeTimeout))
+		}
+		conn.Write(*data)
+		protocol.PutData(data)
+	}
+	s.Plugins.DoPostWriteResponse(ctx, req, res, err)
+	protocol.FreeMsg(res)
+}
+
 func (s *Server) serveConn(conn net.Conn) {
 	if s.isShutdown() {
 		s.closeConn(conn)
@@ -402,20 +421,9 @@ func (s *Server) serveConn(conn net.Conn) {
 				if !req.IsOneway() {
 					res := req.Clone()
 					res.SetMessageType(protocol.Response)
-					if len(res.Payload) > 1024 && req.CompressType() != protocol.None {
-						res.SetCompressType(req.CompressType())
-					}
+
 					handleError(res, err)
-					s.Plugins.DoPreWriteResponse(ctx, req, res, err)
-					data := res.EncodeSlicePointer()
-					if s.AsyncWrite {
-						writeCh <- data
-					} else {
-						conn.Write(*data)
-						protocol.PutData(data)
-					}
-					s.Plugins.DoPostWriteResponse(ctx, req, res, err)
-					protocol.FreeMsg(res)
+					s.sendResponse(ctx, conn, writeCh, err, req, res)
 				} else {
 					s.Plugins.DoPreWriteResponse(ctx, req, nil, err)
 				}
@@ -428,10 +436,6 @@ func (s *Server) serveConn(conn net.Conn) {
 			protocol.FreeMsg(req)
 
 			return
-		}
-
-		if s.writeTimeout != 0 {
-			conn.SetWriteDeadline(t0.Add(s.writeTimeout))
 		}
 
 		if share.Trace {
@@ -449,20 +453,8 @@ func (s *Server) serveConn(conn net.Conn) {
 			if !req.IsOneway() {
 				res := req.Clone()
 				res.SetMessageType(protocol.Response)
-				if len(res.Payload) > 1024 && req.CompressType() != protocol.None {
-					res.SetCompressType(req.CompressType())
-				}
 				handleError(res, err)
-				s.Plugins.DoPreWriteResponse(ctx, req, res, err)
-				data := res.EncodeSlicePointer()
-				if s.AsyncWrite {
-					writeCh <- data
-				} else {
-					conn.Write(*data)
-					protocol.PutData(data)
-				}
-				s.Plugins.DoPostWriteResponse(ctx, req, res, err)
-				protocol.FreeMsg(res)
+				s.sendResponse(ctx, conn, writeCh, err, req, res)
 			} else {
 				s.Plugins.DoPreWriteResponse(ctx, req, nil, err)
 			}
@@ -493,6 +485,9 @@ func (s *Server) serveConn(conn net.Conn) {
 				if s.AsyncWrite {
 					writeCh <- data
 				} else {
+					if s.writeTimeout != 0 {
+						conn.SetWriteDeadline(time.Now().Add(s.writeTimeout))
+					}
 					conn.Write(*data)
 					protocol.PutData(data)
 				}
@@ -535,7 +530,6 @@ func (s *Server) serveConn(conn net.Conn) {
 				}
 			}
 
-			s.Plugins.DoPreWriteResponse(ctx, req, res, err)
 			if !req.IsOneway() {
 				if len(resMetadata) > 0 { // copy meta in context to request
 					meta := res.Metadata
@@ -550,20 +544,8 @@ func (s *Server) serveConn(conn net.Conn) {
 					}
 				}
 
-				if len(res.Payload) > 1024 && req.CompressType() != protocol.None {
-					res.SetCompressType(req.CompressType())
-				}
-				data := res.EncodeSlicePointer()
-				if s.AsyncWrite {
-					writeCh <- data
-				} else {
-					conn.Write(*data)
-					protocol.PutData(data)
-				}
-
+				s.sendResponse(ctx, conn, writeCh, err, req, res)
 			}
-
-			s.Plugins.DoPostWriteResponse(ctx, req, res, err)
 
 			if share.Trace {
 				log.Debugf("server write response %+v for an request %+v from conn: %v", res, req, conn.RemoteAddr().String())
@@ -583,6 +565,9 @@ func (s *Server) serveAsyncWrite(conn net.Conn, writeCh chan *[]byte) {
 		case data := <-writeCh:
 			if data == nil {
 				return
+			}
+			if s.writeTimeout != 0 {
+				conn.SetWriteDeadline(time.Now().Add(s.writeTimeout))
 			}
 			conn.Write(*data)
 			protocol.PutData(data)

--- a/server/server.go
+++ b/server/server.go
@@ -344,7 +344,6 @@ func (s *Server) sendResponse(ctx *share.Context, conn net.Conn, writeCh chan *[
 		protocol.PutData(data)
 	}
 	s.Plugins.DoPostWriteResponse(ctx, req, res, err)
-	protocol.FreeMsg(res)
 }
 
 func (s *Server) serveConn(conn net.Conn) {
@@ -424,6 +423,7 @@ func (s *Server) serveConn(conn net.Conn) {
 
 					handleError(res, err)
 					s.sendResponse(ctx, conn, writeCh, err, req, res)
+					protocol.FreeMsg(res)
 				} else {
 					s.Plugins.DoPreWriteResponse(ctx, req, nil, err)
 				}
@@ -455,6 +455,7 @@ func (s *Server) serveConn(conn net.Conn) {
 				res.SetMessageType(protocol.Response)
 				handleError(res, err)
 				s.sendResponse(ctx, conn, writeCh, err, req, res)
+				protocol.FreeMsg(res)
 			} else {
 				s.Plugins.DoPreWriteResponse(ctx, req, nil, err)
 			}
@@ -518,6 +519,7 @@ func (s *Server) serveConn(conn net.Conn) {
 					log.Errorf("[handler internal error]: servicepath: %s, servicemethod, err: %v", req.ServicePath, req.ServiceMethod, err)
 				}
 
+				protocol.FreeMsg(req)
 				return
 			}
 


### PR DESCRIPTION
Think about this situation:

s.writeTimeout=2 seconds
s.handleRequest() take 3 seconds

Then conn.Write() will always return timeout error because deadline exceed.