### PR TITLE
Update server.go

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -497,6 +497,9 @@ func (s *Server) serveConn(conn net.Conn) {
 			}
 
 			resMetadata := make(map[string]string)
+			if req.Metadata == nil {
+				req.Metadata = make(map[string]string)
+			}
 			ctx = share.WithLocalValue(share.WithLocalValue(ctx, share.ReqMetaDataKey, req.Metadata),
 				share.ResMetaDataKey, resMetadata)
 


### PR DESCRIPTION
避免后续访问空map,当服务端开启链路追踪，客户端未开启，就会造成报错，此处进行判断处理以后，错误码消除