### PR TITLE
Update xclient.go

### DIFF
--- a/client/xclient.go
+++ b/client/xclient.go
@@ -219,9 +219,6 @@ func (c *xClient) Auth(auth string) {
 // watch changes of service and update cached clients.
 func (c *xClient) watch(ch chan []*KVPair) {
 	for pairs := range ch {
-		sort.Slice(pairs, func(i, j int) bool {
-			return strings.Compare(pairs[i].Key, pairs[j].Key) <= 0
-		})
 		servers := make(map[string]string, len(pairs))
 		for _, p := range pairs {
 			servers[p.Key] = p.Value


### PR DESCRIPTION
watch()
many goroutine sort the single slice at the same time. it has a concurrent problem.
and there is no need to sort the pairs, we should delete the sort code.