### PR TITLE
fix: jsonrpc server graceful shutdown

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -74,6 +74,7 @@ type Server struct {
 	readTimeout        time.Duration
 	writeTimeout       time.Duration
 	gatewayHTTPServer  *http.Server
+	jsonrpcHTTPServer  *http.Server
 	DisableHTTPGateway bool // should disable http invoke or not.
 	DisableJSONRPC     bool // should disable json rpc or not.
 	AsyncWrite         bool // set true if your server only serves few clients
@@ -928,6 +929,14 @@ func (s *Server) Shutdown(ctx context.Context) error {
 				log.Warnf("failed to close gateway: %v", err)
 			} else {
 				log.Info("closed gateway")
+			}
+		}
+
+		if s.jsonrpcHTTPServer != nil {
+			if err := s.closeJSONRPC2(ctx); err != nil {
+				log.Warnf("failed to close JSONRPC: %v", err)
+			} else {
+				log.Info("closed JSONRPC")
 			}
 		}
 


### PR DESCRIPTION
一个修改是[调用](https://github.com/smallnest/rpcx/blob/bcc67b78ce0957c763258202e9f7291766604e89/server/gateway.go#L38) `startJSONRPC2` 的时候已经 `go` 了一个 goroutine，所以去掉了 `startJSONRPC2` 里多余的 `go`

另一部分修改是添加了 JSONRPC 服务的 graceful shutdown