### PR TITLE
序列化或者自定义plugins逻辑出现panic,避免业务层channel读阻塞,加入defer保证channel的推送.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -489,7 +489,8 @@ func (client *Client) send(ctx context.Context, call *Call) {
 	// Register this call.
 	defer func() {
 		if r := recover(); r != nil {
-			log.Errorf("client send error is %v", r)
+			call.Error = errors.New(r.(string))
+			log.Warnf("client send error: %v", r)
 		}
 		// write channel ,
 		if call != nil {


### PR DESCRIPTION
序列化或者自定义plugins逻辑出现panic,避免业务层channel读阻塞,加入defer保证channel的推送.