### PR TITLE
Consistent hash selector patch

### DIFF
--- a/client/selector.go
+++ b/client/selector.go
@@ -274,7 +274,7 @@ func (s *consistentHashSelector) UpdateServer(servers map[string]string) {
 	sort.Slice(ss, func(i, j int) bool { return ss[i] < ss[j] })
 
 	for _, k := range s.servers {
-		if servers[k] == "" { // remove
+		if _, exist := servers[k]; !exist { // remove
 			s.h.Remove(k)
 		}
 	}

--- a/client/selector_test.go
+++ b/client/selector_test.go
@@ -21,3 +21,18 @@ func Test_consistentHashSelector_Select(t *testing.T) {
 		}
 	}
 }
+
+func Test_consistentHashSelector_UpdateServer(t *testing.T) {
+	servers := map[string]string{
+		"tcp@192.168.1.16:9392": "",
+		"tcp@192.168.1.16:9393": "",
+	}
+	s := newConsistentHashSelector(servers).(*consistentHashSelector)
+	if len(s.h.All()) != len(servers) {
+		t.Errorf("NewSelector: expected %d server but got %d", len(servers), len(s.h.All()))
+	}
+	s.UpdateServer(servers)
+	if len(s.h.All()) != len(servers) {
+		t.Errorf("UpdateServer: expected %d server but got %d", len(servers), len(s.h.All()))
+	}
+}


### PR DESCRIPTION
The new test case added is failed without the code change in consistentHashSelector.UpdateServer.
That's because the servers map may use empty string "" as value and s.h is cleared when calling  consistentHashSelector.UpdateServer