### PR TITLE
SendRaw should return ResMetadata instead of Metadata

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -439,7 +439,7 @@ func (client *Client) SendRaw(ctx context.Context, r *protocol.Message) (map[str
 		return nil, nil, ctx.Err()
 	case call := <-done:
 		err = call.Error
-		m = call.Metadata
+		m = call.ResMetadata
 		if call.Reply != nil {
 			payload = call.Reply.([]byte)
 		}


### PR DESCRIPTION
I have customized some response metadata, but when calling the sendRaw method to perform rpc operations, I cannot obtain those metadata