### PR TITLE
Replace "ioutil.ReadAll" with "io.ReadAll"

### DIFF
--- a/protocol/compressor.go
+++ b/protocol/compressor.go
@@ -2,7 +2,7 @@ package protocol
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 
 	"github.com/golang/snappy"
 	"github.com/smallnest/rpcx/util"
@@ -67,7 +67,7 @@ func (c *SnappyCompressor) Unzip(data []byte) ([]byte, error) {
 	}
 
 	reader := snappy.NewReader(bytes.NewReader(data))
-	out, err := ioutil.ReadAll(reader)
+	out, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/server/converter.go
+++ b/server/converter.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -85,7 +85,7 @@ func HTTPRequest2RpcxRequest(r *http.Request) (*protocol.Message, error) {
 
 	req.ServiceMethod = h.Get(XServiceMethod)
 
-	payload, err := ioutil.ReadAll(r.Body)
+	payload, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/server/jsonrpc2.go
+++ b/server/jsonrpc2.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -18,7 +18,7 @@ import (
 )
 
 func (s *Server) jsonrpcHandler(w http.ResponseWriter, r *http.Request) {
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -166,7 +166,7 @@ func TestHandler(t *testing.T) {
 		serverConn.Close()
 	}()
 
-	data, err = ioutil.ReadAll(clientConn)
+	data, err = io.ReadAll(clientConn)
 	assert.NoError(t, err)
 
 	resp, err := protocol.Read(bytes.NewReader(data))

--- a/util/compress.go
+++ b/util/compress.go
@@ -3,7 +3,7 @@ package util
 import (
 	"bytes"
 	"compress/gzip"
-	"io/ioutil"
+	"io"
 	"sync"
 )
 
@@ -39,7 +39,7 @@ func Unzip(data []byte) ([]byte, error) {
 	}
 	defer gr.Close()
 
-	data, err = ioutil.ReadAll(gr)
+	data, err = io.ReadAll(gr)
 	if err != nil {
 		return nil, err
 	}

--- a/util/compress_test.go
+++ b/util/compress_test.go
@@ -3,7 +3,7 @@ package util
 import (
 	"bytes"
 	"compress/gzip"
-	"io/ioutil"
+	"io"
 	"testing"
 )
 
@@ -78,7 +78,7 @@ func oldUnzip(data []byte) ([]byte, error) {
 	}
 	defer gr.Close()
 
-	data, err = ioutil.ReadAll(gr)
+	data, err = io.ReadAll(gr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
As of Go 1.16, this function simply calls io.ReadAll.