### PR TITLE
fix: break an infinite loop on file transfer

### DIFF
--- a/client/xclient.go
+++ b/client/xclient.go
@@ -1196,6 +1196,8 @@ loop:
 	for {
 		select {
 		case <-ctx.Done():
+			err = ctx.Err()
+			break loop
 		default:
 			if tb != nil {
 				tb.Wait(FileTransferBufferSize)
@@ -1257,6 +1259,8 @@ loop:
 	for {
 		select {
 		case <-ctx.Done():
+			err = ctx.Err()
+			break loop
 		default:
 			n, er := r.Read(buf)
 			if n > 0 {


### PR DESCRIPTION
A common situation: I want to send a file with timeout.

If the time to send the file expires, ctx.Done() is called. In this case SendFile(...) and DownloadFile(...) functions go into an infinite loop, which cannot be interrupted from outside. I have made correct termination of file transfer in case of ctx.Done().