### PR TITLE
Smmoth_round_roubine:Performance improvement

### DIFF
--- a/client/selector.go
+++ b/client/selector.go
@@ -137,6 +137,7 @@ func (s *weightedRoundRobinSelector) Select(ctx context.Context, servicePath, se
 
 func (s *weightedRoundRobinSelector) UpdateServer(servers map[string]string) {
 	ss := createWeighted(servers)
+	s.buildRing()
 	s.servers = ss
 }
 func (s *weightedRoundRobinSelector) buildRing() {

--- a/client/selector.go
+++ b/client/selector.go
@@ -56,7 +56,7 @@ func newRandomSelector(servers map[string]string) Selector {
 	return &randomSelector{servers: ss}
 }
 
-func (s randomSelector) Select(ctx context.Context, servicePath, serviceMethod string, args interface{}) string {
+func (s *randomSelector) Select(ctx context.Context, servicePath, serviceMethod string, args interface{}) string {
 	ss := s.servers
 	if len(ss) == 0 {
 		return ""
@@ -215,7 +215,7 @@ func newGeoSelector(servers map[string]string, latitude, longitude float64) Sele
 	return &geoSelector{servers: ss, Latitude: latitude, Longitude: longitude, r: r}
 }
 
-func (s geoSelector) Select(ctx context.Context, servicePath, serviceMethod string, args interface{}) string {
+func (s *geoSelector) Select(ctx context.Context, servicePath, serviceMethod string, args interface{}) string {
 	if len(s.servers) == 0 {
 		return ""
 	}
@@ -291,7 +291,7 @@ func newConsistentHashSelector(servers map[string]string) Selector {
 	return &consistentHashSelector{servers: ss, h: h}
 }
 
-func (s consistentHashSelector) Select(ctx context.Context, servicePath, serviceMethod string, args interface{}) string {
+func (s *consistentHashSelector) Select(ctx context.Context, servicePath, serviceMethod string, args interface{}) string {
 	ss := s.servers
 	if len(ss) == 0 {
 		return ""

--- a/client/selector.go
+++ b/client/selector.go
@@ -221,13 +221,13 @@ func (s geoSelector) Select(ctx context.Context, servicePath, serviceMethod stri
 	}
 
 	var server []string
-	min := math.MaxFloat64
+	minNum := math.MaxFloat64
 	for _, gs := range s.servers {
 		d := getDistanceFrom(s.Latitude, s.Longitude, gs.Latitude, gs.Longitude)
-		if d < min {
+		if d < minNum {
 			server = []string{gs.Server}
-			min = d
-		} else if d == min {
+			minNum = d
+		} else if d == minNum {
 			server = append(server, gs.Server)
 		}
 	}

--- a/client/selector_test.go
+++ b/client/selector_test.go
@@ -56,3 +56,16 @@ func TestWeightedRoundRobinSelector_Select(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkWeightedRoundRobinSelector_Select(b *testing.B) {
+	servers := make(map[string]string)
+	servers["ServerA"] = "weight=4"
+	servers["ServerB"] = "weight=2"
+	servers["ServerC"] = "weight=1"
+	ctx := context.Background()
+	weightSelector := newWeightedRoundRobinSelector(servers).(*weightedRoundRobinSelector)
+
+	for i := 0; i < b.N; i++ {
+		weightSelector.Select(ctx, "", "", nil)
+	}
+}

--- a/client/selector_test.go
+++ b/client/selector_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"testing"
 )
 
@@ -34,5 +35,24 @@ func Test_consistentHashSelector_UpdateServer(t *testing.T) {
 	s.UpdateServer(servers)
 	if len(s.h.All()) != len(servers) {
 		t.Errorf("UpdateServer: expected %d server but got %d", len(servers), len(s.h.All()))
+	}
+}
+
+func TestWeightedRoundRobinSelector_Select(t *testing.T) {
+	// a b a c a b a a b a c a b a
+	sers := []string{"ServerA", "ServerB", "ServerA", "ServerC", "ServerA", "ServerB", "ServerA",
+		"ServerA", "ServerB", "ServerA", "ServerC", "ServerA", "ServerB", "ServerA"}
+	servers := make(map[string]string)
+	servers["ServerA"] = "weight=4"
+	servers["ServerB"] = "weight=2"
+	servers["ServerC"] = "weight=1"
+	ctx := context.Background()
+	weightSelector := newWeightedRoundRobinSelector(servers).(*weightedRoundRobinSelector)
+
+	for i := 0; i < 14; i++ {
+		s := weightSelector.Select(ctx, "", "", nil)
+		if s != sers[i] {
+			t.Errorf("expected %s but got %s", sers[i], s)
+		}
 	}
 }


### PR DESCRIPTION
### update smmoth_round_roubine 
rewrite this part code.
when initional i calc the server's weight ,and then add them to a ring.
and then select the server ,only get it from ring.
benchmark 
from 
```
goos: linux
goarch: amd64
pkg: github.com/smallnest/rpcx/client
cpu: AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  
BenchmarkWeightedRoundRobinSelector_Select
BenchmarkWeightedRoundRobinSelector_Select-8   	52450845	         19.27 ns/op
```
to 
```
goos: linux
goarch: amd64
pkg: github.com/smallnest/rpcx/client
cpu: AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  
BenchmarkWeightedRoundRobinSelector_Select
BenchmarkWeightedRoundRobinSelector_Select-8   	384278872	         3.044 ns/op
```
but i think it shuod add a rwlock, old code didn't use it .

