### PR TITLE
faet: increased use of custom routine pools with req.

### DIFF
--- a/server/option.go
+++ b/server/option.go
@@ -54,6 +54,13 @@ func WithCustomPool(pool WorkerPool) OptionFn {
 	}
 }
 
+// WithReqPool uses a custom goroutine pool with req.
+func WithReqPool(reqPool ReqWorkerPool) OptionFn {
+	return func(s *Server) {
+		s.reqPool = reqPool
+	}
+}
+
 // WithAsyncWrite sets AsyncWrite to true.
 func WithAsyncWrite() OptionFn {
 	return func(s *Server) {


### PR DESCRIPTION
添加支持携带 req *protocol.Message 提交任务的协程池支持， 用于支持能依据请求信息编写自定义调度的协程池