### PR TITLE
fix: handler mode write error

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -584,7 +584,12 @@ func (s *Server) processOneRequest(ctx *share.Context, req *protocol.Message, co
 		sctx := NewContext(ctx, conn, req, s.AsyncWrite)
 		err := handler(sctx)
 		if err != nil {
-			log.Errorf("[handler internal error]: servicepath: %s, servicemethod, err: %v", req.ServicePath, req.ServiceMethod, err)
+			if s.HandleServiceError != nil {
+				s.HandleServiceError(err)
+			} else {
+				log.Errorf("[handler internal error]: servicepath: %s, servicemethod, err: %v", req.ServicePath, req.ServiceMethod, err)
+			}
+			sctx.WriteError(err)
 		}
 
 		return


### PR DESCRIPTION
handler 模式下返回 err 时调用WriteError写入错误信息， 如果业务中没有 WriteError 而是直接 `return err` 就会导致客户端一直收不到消息最终响应超时