### PR TITLE
feat: add retry Interval

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -161,6 +161,8 @@ type Option struct {
 
 	// Retries retries to send
 	Retries int
+	// RetryInterval is the interval between retries
+	RetryInterval time.Duration
 	// Time to disallow the bad server not to be selected
 	TimeToDisallow time.Duration
 

--- a/client/xclient.go
+++ b/client/xclient.go
@@ -582,6 +582,7 @@ func (c *xClient) Call(ctx context.Context, serviceMethod string, args interface
 	switch c.failMode {
 	case Failtry:
 		retries := c.option.Retries
+		retryInterval := c.option.RetryInterval
 		for retries >= 0 {
 			retries--
 
@@ -602,6 +603,7 @@ func (c *xClient) Call(ctx context.Context, serviceMethod string, args interface
 				c.removeClient(k, c.servicePath, serviceMethod, client)
 			}
 			client, e = c.getCachedClient(k, c.servicePath, serviceMethod, args)
+			time.Sleep(retryInterval)
 		}
 		if err == nil {
 			err = e
@@ -609,6 +611,7 @@ func (c *xClient) Call(ctx context.Context, serviceMethod string, args interface
 		return err
 	case Failover:
 		retries := c.option.Retries
+		retryInterval := c.option.RetryInterval
 		for retries >= 0 {
 			retries--
 
@@ -628,6 +631,7 @@ func (c *xClient) Call(ctx context.Context, serviceMethod string, args interface
 			if uncoverError(err) {
 				c.removeClient(k, c.servicePath, serviceMethod, client)
 			}
+			time.Sleep(retryInterval)
 			// select another server
 			k, client, e = c.selectClient(ctx, c.servicePath, serviceMethod, args)
 		}


### PR DESCRIPTION
I think we should add retry time for failover and failtry, otherwise a split second retry loses the meaning of retrying