### PR TITLE
修复log中参数不对的问题

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -530,7 +530,7 @@ func (s *Server) processOneRequest(ctx *share.Context, req *protocol.Message, co
 			if s.HandleServiceError != nil {
 				s.HandleServiceError(fmt.Errorf("%v", r))
 			} else {
-				log.Errorf("[handler internal error]: servicepath: %s, servicemethod, err: %v，stacks: %s", req.ServicePath, req.ServiceMethod, r, string(buf))
+				log.Errorf("[handler internal error]: servicepath: %s, servicemethod: %s, err: %v，stacks: %s", req.ServicePath, req.ServiceMethod, r, string(buf))
 			}
 			sctx := NewContext(ctx, conn, req, s.AsyncWrite)
 			sctx.WriteError(fmt.Errorf("%v", r))


### PR DESCRIPTION
修复参数不对称问题，避免打印很奇怪的日志