### PR TITLE
feat: support SetPlugins and GetPlugins for XClientPool and OneClientPool

### DIFF
--- a/client/oneclient_pool.go
+++ b/client/oneclient_pool.go
@@ -14,6 +14,7 @@ type OneClientPool struct {
 	index      uint64
 	oneclients []*OneClient
 	auth       string
+	Plugins    PluginContainer
 
 	failMode          FailMode
 	selectMode        SelectMode
@@ -66,6 +67,20 @@ func (p *OneClientPool) Auth(auth string) {
 	for _, v := range p.oneclients {
 		v.Auth(auth)
 	}
+}
+
+// SetPlugins sets client's plugins.
+func (p *OneClientPool) SetPlugins(plugins PluginContainer) {
+	p.Plugins = plugins
+
+	for _, v := range p.oneclients {
+		v.SetPlugins(plugins)
+	}
+}
+
+// GetPlugins returns client's plugins.
+func (p *OneClientPool) GetPlugins() PluginContainer {
+	return p.Plugins
 }
 
 // Get returns a OneClient.

--- a/client/oneclient_pool_test.go
+++ b/client/oneclient_pool_test.go
@@ -1,0 +1,132 @@
+package client
+
+import (
+	"testing"
+)
+
+func TestOneClientPool_SetPlugins(t *testing.T) {
+	// Create a simple discovery
+	pairs := []*KVPair{
+		{Key: "tcp@127.0.0.1:8972", Value: ""},
+	}
+	discovery, err := NewMultipleServersDiscovery(pairs)
+	if err != nil {
+		t.Fatalf("failed to create discovery: %v", err)
+	}
+	defer discovery.Close()
+
+	// Create a pool
+	pool := NewOneClientPool(3, Failtry, RandomSelect, discovery, DefaultOption)
+	defer pool.Close()
+
+	// Create plugins
+	plugins := NewPluginContainer()
+	tp := &testPlugin{name: "test-plugin"}
+	plugins.Add(tp)
+
+	// Test SetPlugins
+	pool.SetPlugins(plugins)
+
+	// Verify plugins are set on pool
+	if pool.GetPlugins() == nil {
+		t.Error("plugins should not be nil after SetPlugins")
+	}
+	if pool.GetPlugins() != plugins {
+		t.Error("pool plugins should be the same as the set plugins")
+	}
+
+	// Verify plugins are set on all oneclients
+	for i := 0; i < 3; i++ {
+		oneclient := pool.Get()
+		if oneclient.GetPlugins() == nil {
+			t.Errorf("oneclient %d plugins should not be nil", i)
+		}
+		if oneclient.GetPlugins() != plugins {
+			t.Errorf("oneclient %d plugins should be the same as the set plugins", i)
+		}
+	}
+}
+
+func TestOneClientPool_GetPlugins(t *testing.T) {
+	// Create a simple discovery
+	pairs := []*KVPair{
+		{Key: "tcp@127.0.0.1:8972", Value: ""},
+	}
+	discovery, err := NewMultipleServersDiscovery(pairs)
+	if err != nil {
+		t.Fatalf("failed to create discovery: %v", err)
+	}
+	defer discovery.Close()
+
+	// Create a pool
+	pool := NewOneClientPool(2, Failtry, RandomSelect, discovery, DefaultOption)
+	defer pool.Close()
+
+	// Initially, plugins should be nil
+	if pool.GetPlugins() != nil {
+		t.Error("plugins should be nil initially")
+	}
+
+	// Create and set plugins
+	plugins := NewPluginContainer()
+	tp := &testPlugin{name: "test-plugin"}
+	plugins.Add(tp)
+	pool.SetPlugins(plugins)
+
+	// Verify GetPlugins returns the correct plugins
+	retrievedPlugins := pool.GetPlugins()
+	if retrievedPlugins == nil {
+		t.Error("plugins should not be nil after SetPlugins")
+	}
+	if retrievedPlugins != plugins {
+		t.Error("GetPlugins should return the same plugins as SetPlugins")
+	}
+
+	// Verify plugins contain the test plugin
+	allPlugins := retrievedPlugins.All()
+	if len(allPlugins) != 1 {
+		t.Errorf("expected 1 plugin, got %d", len(allPlugins))
+	}
+	if p, ok := allPlugins[0].(*testPlugin); !ok || p.name != "test-plugin" {
+		t.Error("plugin should be the test plugin")
+	}
+}
+
+func TestOneClientPool_SetPlugins_Concurrent(t *testing.T) {
+	// Create a simple discovery
+	pairs := []*KVPair{
+		{Key: "tcp@127.0.0.1:8972", Value: ""},
+	}
+	discovery, err := NewMultipleServersDiscovery(pairs)
+	if err != nil {
+		t.Fatalf("failed to create discovery: %v", err)
+	}
+	defer discovery.Close()
+
+	// Create a pool
+	pool := NewOneClientPool(5, Failtry, RandomSelect, discovery, DefaultOption)
+	defer pool.Close()
+
+	// Test concurrent SetPlugins calls
+	done := make(chan bool, 10)
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			plugins := NewPluginContainer()
+			tp := &testPlugin{name: "test-plugin"}
+			plugins.Add(tp)
+			pool.SetPlugins(plugins)
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Verify plugins are set
+	if pool.GetPlugins() == nil {
+		t.Error("plugins should not be nil after concurrent SetPlugins")
+	}
+}
+

--- a/client/xclient_pool.go
+++ b/client/xclient_pool.go
@@ -22,6 +22,7 @@ type XClientPool struct {
 	discovery   ServiceDiscovery
 	option      Option
 	auth        string
+	Plugins     PluginContainer
 
 	serverMessageChan chan<- *protocol.Message
 }
@@ -73,6 +74,21 @@ func (c *XClientPool) Auth(auth string) {
 		v.Auth(auth)
 	}
 	c.mu.RUnlock()
+}
+
+// SetPlugins sets client's plugins.
+func (p *XClientPool) SetPlugins(plugins PluginContainer) {
+	p.Plugins = plugins
+	p.mu.RLock()
+	for _, v := range p.xclients {
+		v.SetPlugins(plugins)
+	}
+	p.mu.RUnlock()
+}
+
+// GetPlugins returns client's plugins.
+func (p *XClientPool) GetPlugins() PluginContainer {
+	return p.Plugins
 }
 
 // Get returns a xclient.

--- a/client/xclient_pool_test.go
+++ b/client/xclient_pool_test.go
@@ -1,0 +1,137 @@
+package client
+
+import (
+	"testing"
+)
+
+// testPlugin is a simple test plugin implementation
+type testPlugin struct {
+	name string
+}
+
+func TestXClientPool_SetPlugins(t *testing.T) {
+	// Create a simple discovery
+	pairs := []*KVPair{
+		{Key: "tcp@127.0.0.1:8972", Value: ""},
+	}
+	discovery, err := NewMultipleServersDiscovery(pairs)
+	if err != nil {
+		t.Fatalf("failed to create discovery: %v", err)
+	}
+	defer discovery.Close()
+
+	// Create a pool
+	pool := NewXClientPool(3, "Arith", Failtry, RandomSelect, discovery, DefaultOption)
+	defer pool.Close()
+
+	// Create plugins
+	plugins := NewPluginContainer()
+	tp := &testPlugin{name: "test-plugin"}
+	plugins.Add(tp)
+
+	// Test SetPlugins
+	pool.SetPlugins(plugins)
+
+	// Verify plugins are set on pool
+	if pool.GetPlugins() == nil {
+		t.Error("plugins should not be nil after SetPlugins")
+	}
+	if pool.GetPlugins() != plugins {
+		t.Error("pool plugins should be the same as the set plugins")
+	}
+
+	// Verify plugins are set on all xclients
+	for i := 0; i < 3; i++ {
+		xclient := pool.Get()
+		if xclient.GetPlugins() == nil {
+			t.Errorf("xclient %d plugins should not be nil", i)
+		}
+		if xclient.GetPlugins() != plugins {
+			t.Errorf("xclient %d plugins should be the same as the set plugins", i)
+		}
+	}
+}
+
+func TestXClientPool_GetPlugins(t *testing.T) {
+	// Create a simple discovery
+	pairs := []*KVPair{
+		{Key: "tcp@127.0.0.1:8972", Value: ""},
+	}
+	discovery, err := NewMultipleServersDiscovery(pairs)
+	if err != nil {
+		t.Fatalf("failed to create discovery: %v", err)
+	}
+	defer discovery.Close()
+
+	// Create a pool
+	pool := NewXClientPool(2, "Arith", Failtry, RandomSelect, discovery, DefaultOption)
+	defer pool.Close()
+
+	// Initially, plugins should be nil
+	if pool.GetPlugins() != nil {
+		t.Error("plugins should be nil initially")
+	}
+
+	// Create and set plugins
+	plugins := NewPluginContainer()
+	tp := &testPlugin{name: "test-plugin"}
+	plugins.Add(tp)
+	pool.SetPlugins(plugins)
+
+	// Verify GetPlugins returns the correct plugins
+	retrievedPlugins := pool.GetPlugins()
+	if retrievedPlugins == nil {
+		t.Error("plugins should not be nil after SetPlugins")
+	}
+	if retrievedPlugins != plugins {
+		t.Error("GetPlugins should return the same plugins as SetPlugins")
+	}
+
+	// Verify plugins contain the test plugin
+	allPlugins := retrievedPlugins.All()
+	if len(allPlugins) != 1 {
+		t.Errorf("expected 1 plugin, got %d", len(allPlugins))
+	}
+	if p, ok := allPlugins[0].(*testPlugin); !ok || p.name != "test-plugin" {
+		t.Error("plugin should be the test plugin")
+	}
+}
+
+func TestXClientPool_SetPlugins_Concurrent(t *testing.T) {
+	// Create a simple discovery
+	pairs := []*KVPair{
+		{Key: "tcp@127.0.0.1:8972", Value: ""},
+	}
+	discovery, err := NewMultipleServersDiscovery(pairs)
+	if err != nil {
+		t.Fatalf("failed to create discovery: %v", err)
+	}
+	defer discovery.Close()
+
+	// Create a pool
+	pool := NewXClientPool(5, "Arith", Failtry, RandomSelect, discovery, DefaultOption)
+	defer pool.Close()
+
+	// Test concurrent SetPlugins calls
+	done := make(chan bool, 10)
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			plugins := NewPluginContainer()
+			tp := &testPlugin{name: "test-plugin"}
+			plugins.Add(tp)
+			pool.SetPlugins(plugins)
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Verify plugins are set
+	if pool.GetPlugins() == nil {
+		t.Error("plugins should not be nil after concurrent SetPlugins")
+	}
+}
+


### PR DESCRIPTION
## 类型
- [x] Feature（新功能）

## 功能描述
为 `XClientPool` 和 `OneClientPool` 添加 `SetPlugins` 和 `GetPlugins` 方法，使其能够支持插件注册和管理。

## 变更内容
- ✅ 在 `XClientPool` 中添加 `SetPlugins` 和 `GetPlugins` 方法
- ✅ 在 `OneClientPool` 中添加 `SetPlugins` 和 `GetPlugins` 方法
- ✅ 添加完整的测试用例，覆盖基本功能、边界情况和并发场景
- ✅ 遵循与现有 `Auth` 方法相同的实现模式和代码风格

## 实现细节
- `SetPlugins` 方法会将 plugins 设置到 pool 并传递给所有 clients
- `GetPlugins` 方法返回 pool 的 plugins
- 实现方式与 `Auth` 方法保持一致，使用相同的锁机制（XClientPool 使用 RWMutex）

## 测试
- ✅ 所有新增测试用例通过
- ✅ 测试覆盖了基本功能、边界情况和并发场景
- ✅ 代码编译通过，无 lint 错误

## 相关 Issue
https://github.com/smallnest/rpcx/issues/913

## 检查清单
- [x] 代码遵循项目规范
- [x] 添加了测试用例
- [x] 所有测试通过
- [x] 代码编译通过
- [x] 无 lint 错误