### PR TITLE
RDMA(Conn): add net.Conn + net.Listener adapters over rdmanet.Conn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ vendor/
 
 cover.html
 
-.history
+.history.loop-state.json

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
+	github.com/smallnest/gordma v0.3.0 // indirect
 	github.com/templexxx/cpufeat v0.0.0-20180724012125-cef66df7f161 // indirect
 	github.com/templexxx/xor v0.0.0-20191217153810-f85b25db303b // indirect
 	github.com/tjfoc/gmsm v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/samuel/go-zookeeper v0.0.0-20201211165307-7117e9ea2414/go.mod h1:gi+0
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/smallnest/gordma v0.3.0 h1:9C0QrMK5noKzY58TaaHKcjTD1mVASlwuchDutWJK5PE=
+github.com/smallnest/gordma v0.3.0/go.mod h1:fmwIk6y0xfrFNepUmyH89jIka0/sI3NrMq2vh8838cA=
 github.com/smallnest/quick v0.2.0 h1:AEvm7ZovZ6Utv+asFDBh866G4ufMNhRNMKbZHVMFYPE=
 github.com/smallnest/quick v0.2.0/go.mod h1:ODNivpfZTaMgYrNb/fhDtqoEe2TTPxSRo8JaIT/QThI=
 github.com/smallnest/rsocket v0.0.0-20241130031020-4a72eb6ff62a h1:GI6kCNC5AVFbKA6ZKbVd4r+fk+Z7XZCRQm9LURZY4t4=

--- a/share/rdma_conn.go
+++ b/share/rdma_conn.go
@@ -1,0 +1,77 @@
+//go:build rdma
+// +build rdma
+
+package share
+
+import (
+	"net"
+	"time"
+
+	"github.com/smallnest/gordma/rdmanet"
+)
+
+// RDMAAddr adapts an rdmanet string address to net.Addr. Its Network is always
+// "rdma".
+type RDMAAddr string
+
+// Network returns "rdma".
+func (a RDMAAddr) Network() string { return "rdma" }
+
+// String returns the underlying rdmanet address string.
+func (a RDMAAddr) String() string { return string(a) }
+
+// RDMAConn adapts *rdmanet.Conn to net.Conn. rdmanet.Conn already implements
+// Read/Write/Close with built-in message framing and credit-based flow
+// control, so those methods pass through unchanged. This adapter only bridges
+// the remaining net.Conn gaps: LocalAddr/RemoteAddr return a net.Addr instead
+// of a string, and the SetDeadline family is supplied as a documented no-op
+// (rdmanet.Conn has no native deadline support).
+type RDMAConn struct {
+	*rdmanet.Conn
+}
+
+var _ net.Conn = (*RDMAConn)(nil)
+
+// NewRDMAConn wraps an *rdmanet.Conn as a net.Conn.
+func NewRDMAConn(c *rdmanet.Conn) *RDMAConn { return &RDMAConn{Conn: c} }
+
+// LocalAddr returns the local endpoint as a net.Addr.
+func (c *RDMAConn) LocalAddr() net.Addr { return RDMAAddr(c.Conn.LocalAddr()) }
+
+// RemoteAddr returns the remote endpoint as a net.Addr.
+func (c *RDMAConn) RemoteAddr() net.Addr { return RDMAAddr(c.Conn.RemoteAddr()) }
+
+// SetDeadline is a no-op: rdmanet.Conn has no native deadline support. It
+// returns nil so callers that set deadlines (such as rpcx's call paths) are
+// not disrupted, but the deadline is not enforced.
+func (c *RDMAConn) SetDeadline(t time.Time) error { return nil }
+
+// SetReadDeadline is a no-op; see SetDeadline.
+func (c *RDMAConn) SetReadDeadline(t time.Time) error { return nil }
+
+// SetWriteDeadline is a no-op; see SetDeadline.
+func (c *RDMAConn) SetWriteDeadline(t time.Time) error { return nil }
+
+// RDMAListener adapts *rdmanet.Listener to net.Listener. Accept wraps each
+// accepted *rdmanet.Conn in an RDMAConn, and Addr bridges the string address
+// to a net.Addr.
+type RDMAListener struct {
+	*rdmanet.Listener
+}
+
+var _ net.Listener = (*RDMAListener)(nil)
+
+// NewRDMAListener wraps an *rdmanet.Listener as a net.Listener.
+func NewRDMAListener(l *rdmanet.Listener) *RDMAListener { return &RDMAListener{Listener: l} }
+
+// Accept waits for and returns the next connection as a net.Conn.
+func (l *RDMAListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	return NewRDMAConn(c), nil
+}
+
+// Addr returns the listener's network address as a net.Addr.
+func (l *RDMAListener) Addr() net.Addr { return RDMAAddr(l.Listener.Addr()) }


### PR DESCRIPTION
Implements #923.

Adds `share/rdma_conn.go` (`//go:build rdma`):
- `RDMAConn` wraps `*rdmanet.Conn` — Read/Write/Close pass through (rdmanet.Conn already frames + flow-controls); LocalAddr/RemoteAddr bridge string→net.Addr; SetDeadline family is a documented no-op.
- `RDMAListener` wraps `*rdmanet.Listener`; Accept returns the net.Conn adapter.
- Compile-time assertions `var _ net.Conn` / `var _ net.Listener`.

Adds gordma dependency.

Verified: `go build ./...` (default) and `go build -tags rdma ./share/` both pass; `go vet -tags rdma ./share/` clean.

Closes #923