### PR TITLE
RDMA(Conn): replace client rsocket dial with rdmanet.DialTimeout

### DIFF
--- a/client/connection_rdma.go
+++ b/client/connection_rdma.go
@@ -7,7 +7,8 @@ import (
 	"errors"
 	"net"
 
-	"github.com/smallnest/rsocket"
+	"github.com/smallnest/gordma/rdmanet"
+	"github.com/smallnest/rpcx/share"
 )
 
 func init() {
@@ -19,5 +20,9 @@ func newRDMAConn(c *Client, network, address string) (net.Conn, error) {
 		return nil, errors.New("network is not rdma")
 	}
 
-	return rsocket.DialTCP(address)
+	conn, err := rdmanet.DialTimeout(address, c.option.ConnectTimeout)
+	if err != nil {
+		return nil, err
+	}
+	return share.NewRDMAConn(conn), nil
 }


### PR DESCRIPTION
Implements #924. Depends on #923 (merged).

`newRDMAConn` now uses `rdmanet.DialTimeout(address, c.option.ConnectTimeout)` and wraps the `*rdmanet.Conn` in `share.RDMAConn`. No rsocket reference remains in client/.

Verified: `go build ./...` and `go build -tags rdma ./client/` pass; `go vet -tags rdma ./client/` clean.

Closes #924