### PR TITLE
feat(server): add RegisterWithMethods method whitelist

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -99,7 +99,7 @@ func (s *Server) ListServices() []string {
 // The client accesses each method using a string of the form "Type.Method",
 // where Type is the receiver's concrete type.
 func (s *Server) Register(rcvr interface{}, metadata string) error {
-	sname, err := s.register(rcvr, "", false)
+	sname, err := s.register(rcvr, "", false, nil)
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,32 @@ func (s *Server) Register(rcvr interface{}, metadata string) error {
 // RegisterName is like Register but uses the provided name for the type
 // instead of the receiver's concrete type.
 func (s *Server) RegisterName(name string, rcvr interface{}, metadata string) error {
-	_, err := s.register(rcvr, name, true)
+	_, err := s.register(rcvr, name, true, nil)
+	if err != nil {
+		return err
+	}
+	if s.Plugins == nil {
+		s.Plugins = &pluginContainer{}
+	}
+	return s.Plugins.DoRegister(name, rcvr, metadata)
+}
+
+// RegisterWithMethods is like Register but only registers the methods named in
+// the methods whitelist; all other exported methods of the receiver are not
+// exposed as RPC. It returns an error if methods is empty, or if any named
+// method does not exist on the receiver or is not a suitable RPC method.
+func (s *Server) RegisterWithMethods(rcvr interface{}, methods []string, metadata string) error {
+	sname, err := s.register(rcvr, "", false, methods)
+	if err != nil {
+		return err
+	}
+	return s.Plugins.DoRegister(sname, rcvr, metadata)
+}
+
+// RegisterNameWithMethods is like RegisterWithMethods but uses the provided
+// name for the type instead of the receiver's concrete type.
+func (s *Server) RegisterNameWithMethods(name string, rcvr interface{}, methods []string, metadata string) error {
+	_, err := s.register(rcvr, name, true, methods)
 	if err != nil {
 		return err
 	}
@@ -145,7 +170,7 @@ func (s *Server) RegisterFunctionName(servicePath string, name string, fn interf
 	return s.Plugins.DoRegisterFunction(servicePath, name, fn, metadata)
 }
 
-func (s *Server) register(rcvr interface{}, name string, useName bool) (string, error) {
+func (s *Server) register(rcvr interface{}, name string, useName bool, methods []string) (string, error) {
 	s.serviceMapMu.Lock()
 	defer s.serviceMapMu.Unlock()
 
@@ -169,7 +194,37 @@ func (s *Server) register(rcvr interface{}, name string, useName bool) (string, 
 	service.name = sname
 
 	// Install the methods
-	service.method = suitableMethods(service.typ, true)
+	all := suitableMethods(service.typ, true)
+
+	if methods == nil {
+		// No whitelist: register all suitable methods (original behavior).
+		service.method = all
+	} else {
+		// Whitelist: register only the named methods.
+		if len(methods) == 0 {
+			errorStr := "rpcx.Register: empty methods whitelist for " + sname + "; use Register/RegisterName to register all methods"
+			log.Error(errorStr)
+			return sname, errors.New(errorStr)
+		}
+		picked := make(map[string]*methodType)
+		for _, m := range methods {
+			if mt, ok := all[m]; ok {
+				picked[m] = mt
+				continue
+			}
+			// Not suitable: distinguish "no such exported method" from
+			// "exists but its signature is not a suitable RPC method".
+			if _, exists := service.typ.MethodByName(m); exists {
+				errorStr := fmt.Sprintf("rpcx.Register: method %q of %s is not a suitable RPC method", m, sname)
+				log.Error(errorStr)
+				return sname, errors.New(errorStr)
+			}
+			errorStr := fmt.Sprintf("rpcx.Register: method %q not found on %s", m, sname)
+			log.Error(errorStr)
+			return sname, errors.New(errorStr)
+		}
+		service.method = picked
+	}
 
 	if len(service.method) == 0 {
 		var errorStr string

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -33,3 +33,62 @@ func Test_isExportedOrBuiltinType(t *testing.T) {
 	typeOfMul := reflect.TypeOf(Mul)
 	assert.Equal(t, true, isExportedOrBuiltinType(typeOfMul))
 }
+
+// WhitelistArith exposes two suitable RPC methods (Add, Sub), one exported
+// method with an unsuitable signature (NotRPC), and one unexported method.
+type WhitelistArith int
+
+func (t *WhitelistArith) Add(ctx context.Context, args *Args, reply *Reply) error {
+	reply.C = args.A + args.B
+	return nil
+}
+
+func (t *WhitelistArith) Sub(ctx context.Context, args *Args, reply *Reply) error {
+	reply.C = args.A - args.B
+	return nil
+}
+
+// NotRPC is exported but is not a suitable RPC method (wrong signature).
+func (t *WhitelistArith) NotRPC() string { return "not rpc" }
+
+func TestRegisterWithMethods_subset(t *testing.T) {
+	s := NewServer()
+	err := s.RegisterWithMethods(new(WhitelistArith), []string{"Add"}, "")
+	assert.NoError(t, err)
+
+	svc := s.serviceMap["WhitelistArith"]
+	assert.NotNil(t, svc)
+	assert.Equal(t, 1, len(svc.method))
+	_, hasAdd := svc.method["Add"]
+	_, hasSub := svc.method["Sub"]
+	assert.True(t, hasAdd)
+	assert.False(t, hasSub) // Sub is suitable but not whitelisted
+}
+
+func TestRegisterWithMethods_notFound(t *testing.T) {
+	s := NewServer()
+	err := s.RegisterWithMethods(new(WhitelistArith), []string{"Add", "Nope"}, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Nope")
+	assert.Contains(t, err.Error(), "not found")
+	// No partial registration.
+	assert.Nil(t, s.serviceMap["WhitelistArith"])
+}
+
+func TestRegisterWithMethods_notSuitable(t *testing.T) {
+	s := NewServer()
+	err := s.RegisterWithMethods(new(WhitelistArith), []string{"Add", "NotRPC"}, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "NotRPC")
+	assert.Contains(t, err.Error(), "not a suitable")
+	assert.Nil(t, s.serviceMap["WhitelistArith"])
+}
+
+func TestRegisterNameWithMethods_subset(t *testing.T) {
+	s := NewServer()
+	err := s.RegisterNameWithMethods("Calc", new(WhitelistArith), []string{"Add", "Sub"}, "")
+	assert.NoError(t, err)
+	svc := s.serviceMap["Calc"]
+	assert.NotNil(t, svc)
+	assert.Equal(t, 2, len(svc.method))
+}


### PR DESCRIPTION
Implements #931 (sub-issue of #581).

Adds `RegisterWithMethods`/`RegisterNameWithMethods`. Internal `register` gains a `methods []string` param — `nil` = register all (unchanged), non-nil = whitelist filtered against `suitableMethods`. Absent method → 'not found' error; exists-but-unsuitable → 'not a suitable RPC method' error (distinguished via `MethodByName`); empty whitelist → error. No partial registration on error. `Register`/`RegisterName` pass `nil`, behavior unchanged.

Verified: `go build ./...`, `go test ./server/` pass (incl. 4 new tests + zero regression).

Closes #931