### PR TITLE
feat(server): guard empty whitelist in WithMethods entry points

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -124,6 +124,9 @@ func (s *Server) RegisterName(name string, rcvr interface{}, metadata string) er
 // exposed as RPC. It returns an error if methods is empty, or if any named
 // method does not exist on the receiver or is not a suitable RPC method.
 func (s *Server) RegisterWithMethods(rcvr interface{}, methods []string, metadata string) error {
+	if len(methods) == 0 {
+		return errors.New("rpcx.Register: empty methods whitelist; use Register to register all methods")
+	}
 	sname, err := s.register(rcvr, "", false, methods)
 	if err != nil {
 		return err
@@ -134,6 +137,9 @@ func (s *Server) RegisterWithMethods(rcvr interface{}, methods []string, metadat
 // RegisterNameWithMethods is like RegisterWithMethods but uses the provided
 // name for the type instead of the receiver's concrete type.
 func (s *Server) RegisterNameWithMethods(name string, rcvr interface{}, methods []string, metadata string) error {
+	if len(methods) == 0 {
+		return errors.New("rpcx.Register: empty methods whitelist; use RegisterName to register all methods")
+	}
 	_, err := s.register(rcvr, name, true, methods)
 	if err != nil {
 		return err

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -92,3 +92,27 @@ func TestRegisterNameWithMethods_subset(t *testing.T) {
 	assert.NotNil(t, svc)
 	assert.Equal(t, 2, len(svc.method))
 }
+
+func TestRegisterWithMethods_emptyWhitelist(t *testing.T) {
+	// nil slice: empty whitelist → error, nothing registered.
+	s := NewServer()
+	err := s.RegisterWithMethods(new(WhitelistArith), nil, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty methods whitelist")
+	assert.Nil(t, s.serviceMap["WhitelistArith"])
+
+	// zero-length slice: same.
+	s2 := NewServer()
+	err = s2.RegisterWithMethods(new(WhitelistArith), []string{}, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty methods whitelist")
+	assert.Nil(t, s2.serviceMap["WhitelistArith"])
+}
+
+func TestRegisterNameWithMethods_emptyWhitelist(t *testing.T) {
+	s := NewServer()
+	err := s.RegisterNameWithMethods("Calc", new(WhitelistArith), nil, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty methods whitelist")
+	assert.Nil(t, s.serviceMap["Calc"])
+}


### PR DESCRIPTION
Implements #932 (sub-issue of #581). Depends on #931 (merged).

`RegisterWithMethods`/`RegisterNameWithMethods` now reject nil/empty `methods` at the public boundary with a message pointing to `Register`/`RegisterName`. Nothing is registered on error. Internal `register`'s `nil` = register-all path is untouched.

Verified: `go build ./...`, `go test ./server/` pass (incl. 2 new empty-whitelist tests covering nil and zero-length).

Closes #932