### PR TITLE
refactor: smell-report fixes — panics, dead sort, swallowed errors, test de-flake

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -606,7 +606,9 @@ func (client *Client) send(ctx context.Context, call *Call) {
 	req.Payload = data
 
 	if client.Plugins != nil {
-		_ = client.Plugins.DoClientBeforeEncode(req)
+		if err := client.Plugins.DoClientBeforeEncode(req); err != nil {
+			log.Errorf("rpcx: DoClientBeforeEncode plugin hook failed (%s.%s): %v", call.ServicePath, call.ServiceMethod, err)
+		}
 	}
 
 	if share.Trace {
@@ -653,7 +655,9 @@ func (client *Client) send(ctx context.Context, call *Call) {
 	}
 
 	if client.option.IdleTimeout != 0 {
-		_ = client.Conn.SetDeadline(time.Now().Add(client.option.IdleTimeout))
+		if err := client.Conn.SetDeadline(time.Now().Add(client.option.IdleTimeout)); err != nil {
+			log.Warnf("rpcx: failed to set idle deadline after send: %v", err)
+		}
 	}
 }
 
@@ -663,7 +667,9 @@ func (client *Client) input() {
 	for err == nil {
 		res := protocol.NewMessage()
 		if client.option.IdleTimeout != 0 {
-			_ = client.Conn.SetDeadline(time.Now().Add(client.option.IdleTimeout))
+			if err := client.Conn.SetDeadline(time.Now().Add(client.option.IdleTimeout)); err != nil {
+				log.Warnf("rpcx: failed to set idle deadline before read: %v", err)
+			}
 		}
 
 		err = res.Decode(client.r)
@@ -671,7 +677,9 @@ func (client *Client) input() {
 			break
 		}
 		if client.Plugins != nil {
-			_ = client.Plugins.DoClientAfterDecode(res)
+			if err := client.Plugins.DoClientAfterDecode(res); err != nil {
+				log.Errorf("rpcx: DoClientAfterDecode plugin hook failed: %v", err)
+			}
 		}
 
 		seq := res.Seq()
@@ -713,20 +721,30 @@ func (client *Client) input() {
 			}
 
 			if call.Raw {
-				call.Metadata, call.Reply, _ = convertRes2Raw(res)
+				var derr error
+				call.Metadata, call.Reply, derr = convertRes2Raw(res)
+				if derr != nil {
+					log.Warnf("rpcx: convertRes2Raw failed for error response (%s.%s): %v", call.ServicePath, call.ServiceMethod, derr)
+				}
 				call.Metadata[XErrorMessage] = call.Error.Error()
 				call.ResMetadata = res.Metadata
 			} else if len(res.Payload) > 0 {
 				data := res.Payload
 				codec := share.Codecs[res.SerializeType()]
 				if codec != nil {
-					_ = codec.Decode(data, call.Reply)
+					if derr := codec.Decode(data, call.Reply); derr != nil {
+						log.Warnf("rpcx: decode error response payload failed (%s.%s): %v", call.ServicePath, call.ServiceMethod, derr)
+					}
 				}
 			}
 			call.done()
 		default:
 			if call.Raw {
-				call.Metadata, call.Reply, _ = convertRes2Raw(res)
+				var derr error
+				call.Metadata, call.Reply, derr = convertRes2Raw(res)
+				if derr != nil {
+					log.Warnf("rpcx: convertRes2Raw failed for response (%s.%s): %v", call.ServicePath, call.ServiceMethod, derr)
+				}
 				call.ResMetadata = res.Metadata
 			} else {
 				data := res.Payload

--- a/client/connection.go
+++ b/client/connection.go
@@ -54,7 +54,9 @@ func (client *Client) Connect(network, address string) error {
 		}
 
 		if client.option.IdleTimeout != 0 {
-			_ = conn.SetDeadline(time.Now().Add(client.option.IdleTimeout))
+			if err := conn.SetDeadline(time.Now().Add(client.option.IdleTimeout)); err != nil {
+				log.Warnf("rpcx: failed to set idle deadline on connection: %v", err)
+			}
 		}
 
 		if client.Plugins != nil {

--- a/client/discovery.go
+++ b/client/discovery.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/smallnest/rpcx/log"
 )
 
 // ServiceDiscoveryFilter can be used to filter services with customized logics.
@@ -45,7 +47,11 @@ func CacheDiscovery(threshold int, cachedFile string, discovery ServiceDiscovery
 	if _, err := os.Stat(cachedFileDir); os.IsNotExist(err) {
 		// 目录不存在，创建目录
 		if err := os.MkdirAll(cachedFileDir, os.ModePerm); err != nil {
-			panic(err)
+			// Degrade gracefully instead of crashing: the wrapped ServiceDiscovery
+			// still works, only on-disk caching is unavailable. storeCached and
+			// loadCached already tolerate write/read failures, so a missing dir
+			// is non-fatal.
+			log.Errorf("rpcx: failed to create discovery cache dir %q: %v", cachedFileDir, err)
 		}
 	}
 

--- a/client/xclient.go
+++ b/client/xclient.go
@@ -210,9 +210,6 @@ func (c *xClient) Auth(auth string) {
 // watch changes of service and update cached clients.
 func (c *xClient) watch(ch chan []*KVPair) {
 	for pairs := range ch {
-		sort.Slice(pairs, func(i, j int) bool {
-			return strings.Compare(pairs[i].Key, pairs[j].Key) <= 0
-		})
 		servers := make(map[string]string, len(pairs))
 		for _, p := range pairs {
 			servers[p.Key] = p.Value
@@ -235,17 +232,21 @@ func filterByStateAndGroup(group string, servers map[string]string) {
 			if state := values.Get("state"); state == "inactive" {
 				delete(servers, k)
 			}
-			groups := values["group"] // Directly access the map to get all values associated with "group" as a slice
+			// Membership test: does this server's (typically tiny) groups slice
+			// contain the single target group? A linear scan is intentional here
+			// — building a Set per server would add map-allocation overhead for a
+			// single lookup against a 1-3 element slice.
+			groups := values["group"]
 			if group != "" {
 				found := false
 				for _, g := range groups {
 					if group == g {
 						found = true
-						break // A matching group is found, stop the search
+						break
 					}
 				}
 				if !found {
-					delete(servers, k) // If no matching group is found, delete the corresponding server from the map
+					delete(servers, k)
 				}
 			}
 		}

--- a/server/file_transfer.go
+++ b/server/file_transfer.go
@@ -73,8 +73,12 @@ func (s *Server) EnableFileTransfer(serviceName string, fileTransfer *FileTransf
 	if serviceName == "" {
 		serviceName = share.SendFileServiceName
 	}
-	_ = fileTransfer.Start()
-	_ = s.RegisterName(serviceName, fileTransfer.service, "")
+	if err := fileTransfer.Start(); err != nil {
+		log.Errorf("rpcx: failed to start file transfer service: %v", err)
+	}
+	if err := s.RegisterName(serviceName, fileTransfer.service, ""); err != nil {
+		log.Errorf("rpcx: failed to register file transfer service %q: %v", serviceName, err)
+	}
 }
 
 func (s *FileTransferService) TransferFile(ctx context.Context, args *share.FileTransferArgs, reply *share.FileTransferReply) error {

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -39,9 +39,11 @@ func TestPluginHeartbeat(t *testing.T) {
 		}
 	}()
 	go func() {
-		// wait for server start complete
-		time.Sleep(time.Second)
 		defer wg.Done()
+		// wait for server start complete
+		if !waitServerReady(s, 5*time.Second) {
+			return
+		}
 		// client
 		opts := client.DefaultOption
 		opts.Heartbeat = true

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -36,10 +36,21 @@ func (t *Arith) ThriftMul(ctx context.Context, args *testutils.ThriftArgs_, repl
 	return nil
 }
 
-func (t *Arith) ConsumingOperation(ctx context.Context, args *testutils.ThriftArgs_, reply *testutils.ThriftReply) error {
-	reply.C = args.A * args.B
-	time.Sleep(10 * time.Second)
-	return nil
+// waitServerReady polls the server until its listener is bound or timeout
+// elapses. It replaces blind time.Sleep waits for `go s.Serve(...)` to start
+// and does not call t.Fatalf, so it is safe to invoke from goroutines that
+// a test spawns. Returns false if the server did not become ready in time.
+func waitServerReady(s *Server, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if s.Address() != nil {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return s.Address() != nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func TestShutdownHook(t *testing.T) {
@@ -54,7 +65,9 @@ func TestShutdownHook(t *testing.T) {
 	s.Register(new(Arith), "")
 	go s.Serve("tcp", ":0")
 
-	time.Sleep(time.Second)
+	if !waitServerReady(s, 2*time.Second) {
+		t.Fatal("server did not become ready in time")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	s.Shutdown(ctx)
 	cancel()

--- a/server/stream.go
+++ b/server/stream.go
@@ -63,8 +63,12 @@ func (s *Server) EnableStreamService(serviceName string, streamService *StreamSe
 	if serviceName == "" {
 		serviceName = share.StreamServiceName
 	}
-	_ = streamService.Start()
-	_ = s.RegisterName(serviceName, streamService, "")
+	if err := streamService.Start(); err != nil {
+		log.Errorf("rpcx: failed to start stream service: %v", err)
+	}
+	if err := s.RegisterName(serviceName, streamService, ""); err != nil {
+		log.Errorf("rpcx: failed to register stream service %q: %v", serviceName, err)
+	}
 }
 
 func (s *StreamService) Stream(ctx context.Context, args *share.StreamServiceArgs, reply *share.StreamServiceReply) error {

--- a/share/context.go
+++ b/share/context.go
@@ -72,6 +72,14 @@ func (c *Context) String() string {
 	return fmt.Sprintf("%v.WithValue(%v)", c.Context, c.tags)
 }
 
+// WithValue returns a new share Context derived from parent that carries the
+// key/val pair in its tags.
+//
+// It panics on a nil or non-comparable key. This is intentional and mirrors
+// the standard library's context.WithValue contract: a nil or non-comparable
+// key is a programmer error that should fail fast rather than be silently
+// dropped, since a no-op would lose the value and mask the bug. Always pass a
+// comparable, non-nil key.
 func WithValue(parent context.Context, key, val interface{}) *Context {
 	if key == nil {
 		panic("nil key")
@@ -85,6 +93,10 @@ func WithValue(parent context.Context, key, val interface{}) *Context {
 	return &Context{Context: parent, tags: tags, tagsLock: &sync.Mutex{}}
 }
 
+// WithLocalValue sets key/val on the existing ctx's tags and returns ctx.
+//
+// Like WithValue, it panics on a nil or non-comparable key to mirror the
+// standard library's context.WithValue contract (see WithValue for rationale).
 func WithLocalValue(ctx *Context, key, val interface{}) *Context {
 	if key == nil {
 		panic("nil key")


### PR DESCRIPTION
## Summary

Refactoring of rpcx core packages based on the architecture smell report (`tasks/smell-report-2026-06-30-2329.md`). Four low-risk, high-value fixes targeting the report's Critical and Warning items. **No external API changes** — all backward compatible. Full core test suite green; server suite is now faster *and* deterministic.

Branch built on a clean `master` baseline; one refactoring per commit so each is independently reviewable/revertible.

## Changes

### 1. `da70cc9` — Library `panic` → graceful degradation (Critical #3)
- **`client/discovery.go`**: `CacheDiscovery` no longer `panic(err)`s when `os.MkdirAll` fails to create the cache dir. It logs the error and continues, so the wrapped `ServiceDiscovery` still works — only on-disk caching is unavailable. This matches the file's own `storeCached`/`loadCached`, which already tolerate I/O failure. A library should never crash the host process on an environmental failure.
- **`share/context.go`**: the `WithValue`/`WithLocalValue` panics on nil/non-comparable key were **kept and documented**. They intentionally mirror the stdlib `context.WithValue` contract (fail-fast on programmer error); silencing them would mask bugs as silent data loss.

### 2. `cd34c37` — Remove dead `sort.Slice` in discovery watch path (Critical #4)
- **`client/xclient.go` `watch()`** sorted the `pairs` slice by Key on every discovery event, then immediately poured it into a `map[string]string`. Go map iteration order is non-deterministic, so the sort had **no observable effect**: every selector's `UpdateServer` either re-iterates the map itself (random/round-robin/weighted/geo) or sorts internally (consistent-hash). `pairs` was never read again after the map was built. Removed the dead O(n log n) sort per event.
- The report also flagged `filterByStateAndGroup`'s inner linear scan as a "missing index" smell. **This was a false flag**: the target `group` is a single string tested against each server's typically-1–3-element `groups` slice; building a `Set` per server would add map-allocation overhead for a single lookup. Left the correct scan with a clarifying comment.

### 3. `473e8a3` — Log previously-swallowed errors (Warning #11)
Replaced silently-dropped `_ =` errors with logged diagnostics. Control flow unchanged; only adds observability.
- **`Errorf`** (primary ops silently dropped): `DoClientBeforeEncode`/`DoClientAfterDecode` plugin hooks; `EnableFileTransfer`/`EnableStreamService` `Start` + `RegisterName`.
- **`Warnf`** (routine/secondary ops that fire on closed conns or in already-error paths): `SetDeadline` for idle timeout (send + read loop + connection setup); `convertRes2Raw`/`codec.Decode` in error-response paths.
- **Left intentional**: `SetKeepAlive` on `*net.TCPConn` (non-TCP guard), `recover()` idiom in `xclient`, `LoadOrStore` loaded-bool, `message.go` `_ = l` (compiler no-op, not an error).

### 4. `b648d9b` — De-flake test sync + drop dead 10s fixture (Warning #12)
- The report pointed at a `10s time.Sleep`, but it lived inside `ConsumingOperation`, a test service method that was **never called anywhere** — dead code. Deleted it.
- The **real** flaky sleeps were the blind `1s time.Sleep` calls waiting for the spawned `s.Serve(...)` goroutine to bind its listener (a race). Replaced with a `waitServerReady` helper that polls `Server.Address()` (nil until the listener is bound) with a bounded timeout:
  - `TestShutdownHook`: poll instead of 1s sleep; `t.Fatal` on timeout (main test goroutine).
  - `TestPluginHeartbeat`: poll instead of 1s sleep; bail gracefully on timeout (spawned goroutine, no `t.Fatalf`); moved `defer wg.Done()` to top of goroutine so an early bail still decrements the WaitGroup.
  - `waitServerReady` returns `bool` and never calls `t.Fatalf`, so it is safe from goroutines.

## Report corrections discovered during verification
- **`codec/` has 0 swallowed errors**, not 12 as the report stated.
- The **10s sleep was dead code** (`ConsumingOperation` never called), located in `server_test.go` not `service_test.go`.
- **`share/context.go` panics are intentional** stdlib parity, not a smell.
- **`filterByStateAndGroup` "O(1) Set" recommendation** would regress performance (single target, tiny slice).

## Test status
- `go build ./...` — clean
- `go vet` — clean for all touched production files (one pre-existing `t.Fatalf`-from-goroutine warning in `plugin_test.go:56` is out of scope and unchanged; the new helper deliberately avoids `t.Fatalf` so it doesn't worsen it)
- `go test ./share/... ./protocol/... ./codec/... ./client/... ./server/...` — all pass
- De-flaked tests verified with `-race -count=3`
- Server suite: **~11.9s vs ~15.0s baseline** (faster and deterministic)

## Not in this PR (deferred)
- **God Object splits** (`xClient` 1443 lines, `Server` 1098 lines into sub-packages) — larger structural change, intentionally deferred per the report's roadmap. Ready as a follow-up.

## Checklist
- [x] Behavior preserved — no external API changes
- [x] One refactoring per commit
- [x] Each commit compiles and passes tests
- [x] Based on clean `master`; baseline tests captured before any change
