### PR TITLE
perf(client): release xClient mutex before dialing; server pool/mutex cleanups

### DIFF
--- a/client/xclient_discovery.go
+++ b/client/xclient_discovery.go
@@ -126,40 +126,59 @@ func (c *xClient) getCachedClient(k string, servicePath, serviceMethod string, _
 		return nil, ErrBreakerOpen
 	}
 
+	// Fast path: only the cache map lookup is guarded by c.mu.
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	client = c.findCachedClient(k, servicePath, serviceMethod)
 	if client != nil {
 		if !client.IsClosing() && !client.IsShutdown() {
+			c.mu.Unlock()
 			return client, nil
 		}
 		c.deleteCachedClient(client, k, servicePath, serviceMethod)
+		client = nil
+	}
+	c.mu.Unlock()
+
+	// Slow path: dial outside c.mu so a slow or hanging Connect cannot block
+	// other callers of this xClient. singleflight dedups concurrent dials to
+	// the same key; created is set only by the goroutine that actually dials,
+	// so the DoClientConnected plugin fires exactly once per new connection.
+	var created bool
+	generatedClient, err, _ := c.slGroup.Do(k, func() (interface{}, error) {
+		// Re-check the cache: another goroutine may have cached a client for k
+		// between our fast-path unlock and entering singleflight.
+		c.mu.Lock()
+		if cached := c.findCachedClient(k, servicePath, serviceMethod); cached != nil &&
+			!cached.IsClosing() && !cached.IsShutdown() {
+			c.mu.Unlock()
+			return cached, nil
+		}
+		c.mu.Unlock()
+
+		newClient, gerr := c.generateClient(k, servicePath, serviceMethod)
+		if gerr != nil {
+			return nil, gerr
+		}
+		newClient.RegisterServerMessageChan(c.serverMessageChan)
+
+		c.mu.Lock()
+		c.setCachedClient(newClient, k, servicePath, serviceMethod)
+		c.mu.Unlock()
+
+		created = true
+		return newClient, nil
+	})
+
+	// forget k so a later dial for the same key is not deduped against this one
+	c.slGroup.Forget(k)
+
+	if err != nil {
+		return nil, err
 	}
 
-	client = c.findCachedClient(k, servicePath, serviceMethod)
-
-	if client == nil || client.IsShutdown() {
-		generatedClient, err, _ := c.slGroup.Do(k, func() (interface{}, error) {
-			return c.generateClient(k, servicePath, serviceMethod)
-		})
-
-		if err != nil {
-			c.slGroup.Forget(k)
-			return nil, err
-		}
-
-		client = generatedClient.(RPCClient)
-		if c.Plugins != nil {
-			needCallPlugin = true
-		}
-
-		client.RegisterServerMessageChan(c.serverMessageChan)
-
-		c.setCachedClient(client, k, servicePath, serviceMethod)
-
-		// forget k only when client is cached
-		c.slGroup.Forget(k)
+	client = generatedClient.(RPCClient)
+	if created && c.Plugins != nil {
+		needCallPlugin = true
 	}
 
 	return client, nil

--- a/client/xclient_discovery_test.go
+++ b/client/xclient_discovery_test.go
@@ -1,0 +1,123 @@
+package client
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/smallnest/rpcx/protocol"
+)
+
+// stubClient is a no-op RPCClient used as cached entries in discovery tests.
+type stubClient struct{}
+
+func (m *stubClient) Connect(network, address string) error { return nil }
+func (m *stubClient) Go(ctx context.Context, sp, sm string, args, reply interface{}, done chan *Call) *Call {
+	return nil
+}
+func (m *stubClient) Call(ctx context.Context, sp, sm string, args, reply interface{}) error {
+	return nil
+}
+func (m *stubClient) SendRaw(ctx context.Context, r *protocol.Message) (map[string]string, []byte, error) {
+	return nil, nil, nil
+}
+func (m *stubClient) Close() error                                         { return nil }
+func (m *stubClient) RemoteAddr() string                                   { return "" }
+func (m *stubClient) RegisterServerMessageChan(ch chan<- *protocol.Message) {}
+func (m *stubClient) UnregisterServerMessageChan()                         {}
+func (m *stubClient) IsClosing() bool                                      { return false }
+func (m *stubClient) IsShutdown() bool                                     { return false }
+func (m *stubClient) GetConn() net.Conn                                    { return nil }
+
+// TestGetCachedClientDialDoesNotBlockOtherKeys asserts that while a dial for
+// key A is in flight (blocked in Connect), a getCachedClient for an
+// already-cached key B returns promptly. Before the fix, c.mu was held across
+// the blocking Connect, serializing all callers of the xClient.
+func TestGetCachedClientDialDoesNotBlockOtherKeys(t *testing.T) {
+	c := &xClient{
+		cachedClient: make(map[string]RPCClient),
+		Plugins:      &pluginContainer{},
+	}
+
+	const slowKey = "tcp@slow:1234"
+	const fastKey = "tcp@fast:5678"
+
+	// Pre-cache a ready client for fastKey so getCachedClient(fastKey) hits the
+	// fast (cache-only) path.
+	fast := &stubClient{}
+	c.cachedClient[fastKey] = fast
+
+	slow := &stubClient{}
+	dialBlock := make(chan struct{}) // GenerateClient(slowKey) blocks until closed
+	dialing := make(chan struct{})   // closed when the slow dial starts
+
+	// Route the dial for slowKey through a builder whose GenerateClient blocks,
+	// simulating a slow/hanging Connect.
+	RegisterCacheClientBuilder("tcp", &mockBuilder{
+		cache: c.cachedClient,
+		gen: func(k string) (RPCClient, error) {
+			close(dialing)
+			<-dialBlock
+			return slow, nil
+		},
+	})
+	t.Cleanup(func() {
+		cacheClientBuildersMutex.Lock()
+		delete(cacheClientBuilders, "tcp")
+		cacheClientBuildersMutex.Unlock()
+	})
+
+	// Start a slow dial for slowKey in the background.
+	dialDone := make(chan struct{})
+	go func() {
+		_, _ = c.getCachedClient(slowKey, "p", "m", nil)
+		close(dialDone)
+	}()
+
+	// Wait until the slow dial is actually in GenerateClient (dialing).
+	select {
+	case <-dialing:
+	case <-time.After(2 * time.Second):
+		t.Fatal("slow dial never started")
+	}
+
+	// Now a lookup for the already-cached fastKey must return promptly.
+	got := make(chan RPCClient, 1)
+	go func() {
+		cl, err := c.getCachedClient(fastKey, "p", "m", nil)
+		if err != nil {
+			t.Errorf("getCachedClient(fastKey): %v", err)
+		}
+		got <- cl
+	}()
+
+	select {
+	case cl := <-got:
+		if cl != fast {
+			t.Fatalf("expected cached fast client, got %v", cl)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("getCachedClient(fastKey) blocked behind slow dial — c.mu held across Connect")
+	}
+
+	// Release the slow dial and let it finish.
+	close(dialBlock)
+	<-dialDone
+}
+
+// mockBuilder is a CacheClientBuilder backed by the same map as the xClient
+// under test. Its cache ops run under the xClient's c.mu (getCachedClient holds
+// it around FindCachedClient/SetCachedClient), while GenerateClient runs
+// lock-free — exactly the property under test.
+type mockBuilder struct {
+	cache map[string]RPCClient
+	gen   func(k string) (RPCClient, error)
+}
+
+func (b *mockBuilder) SetCachedClient(client RPCClient, k, sp, sm string) { b.cache[k] = client }
+func (b *mockBuilder) FindCachedClient(k, sp, sm string) RPCClient        { return b.cache[k] }
+func (b *mockBuilder) DeleteCachedClient(client RPCClient, k, sp, sm string) {
+	delete(b.cache, k)
+}
+func (b *mockBuilder) GenerateClient(k, sp, sm string) (RPCClient, error) { return b.gen(k) }

--- a/server/server_bench_test.go
+++ b/server/server_bench_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/smallnest/rpcx/protocol"
+	"github.com/smallnest/rpcx/share"
+)
+
+// benchArith is a minimal service whose arg/reply types implement Reset so the
+// server object pool actually reuses them (mirroring the intended hot path).
+// It reuses the exported Args/Reply from server_test.go via BenchArgs/BenchReply
+// aliases that add Reset; the types must be exported to be suitable RPC methods.
+type benchArith int
+
+type BenchArgs struct {
+	A int
+	B int
+}
+
+func (a *BenchArgs) Reset() { a.A, a.B = 0, 0 }
+
+type BenchReply struct {
+	C int
+}
+
+func (r *BenchReply) Reset() { r.C = 0 }
+
+func (t *benchArith) Mul(ctx context.Context, args *BenchArgs, reply *BenchReply) error {
+	reply.C = args.A * args.B
+	return nil
+}
+
+// newBenchRequest builds a JSON-encoded Mul request message.
+func newBenchRequest(b *testing.B) *protocol.Message {
+	b.Helper()
+	codec := share.Codecs[protocol.JSON]
+	payload, err := codec.Encode(&BenchArgs{A: 7, B: 6})
+	if err != nil {
+		b.Fatalf("encode payload: %v", err)
+	}
+	req := protocol.NewMessage()
+	req.SetMessageType(protocol.Request)
+	req.SetSerializeType(protocol.JSON)
+	req.ServicePath = "benchArith"
+	req.ServiceMethod = "Mul"
+	req.Payload = payload
+	return req
+}
+
+// BenchmarkServerHandleRequest exercises the per-request dispatch path
+// (service lookup, arg/reply pool Get/Put, decode, call, encode). It is the
+// benchmark used to validate object-pool changes in server_dispatch.go.
+func BenchmarkServerHandleRequest(b *testing.B) {
+	s := NewServer()
+	if err := s.RegisterName("benchArith", new(benchArith), ""); err != nil {
+		b.Fatalf("register: %v", err)
+	}
+	req := newBenchRequest(b)
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := s.handleRequest(ctx, req)
+		if err != nil {
+			b.Fatalf("handleRequest: %v", err)
+		}
+		_ = res
+	}
+}

--- a/server/server_dispatch.go
+++ b/server/server_dispatch.go
@@ -47,12 +47,14 @@ func (s *Server) handleRequest(ctx context.Context, req *protocol.Message) (res 
 
 	codec := share.Codecs[req.SerializeType()]
 	if codec == nil {
+		reflectTypePools.Put(mtype.ArgType, argv)
 		err = fmt.Errorf("can not find codec for %d", req.SerializeType())
 		return s.handleError(res, err)
 	}
 
 	err = codec.Decode(req.Payload, argv)
 	if err != nil {
+		reflectTypePools.Put(mtype.ArgType, argv)
 		return s.handleError(res, err)
 	}
 
@@ -136,12 +138,14 @@ func (s *Server) handleRequestForFunction(ctx context.Context, req *protocol.Mes
 
 	codec := share.Codecs[req.SerializeType()]
 	if codec == nil {
+		reflectTypePools.Put(mtype.ArgType, argv)
 		err = fmt.Errorf("can not find codec for %d", req.SerializeType())
 		return s.handleError(res, err)
 	}
 
 	err = codec.Decode(req.Payload, argv)
 	if err != nil {
+		reflectTypePools.Put(mtype.ArgType, argv)
 		return s.handleError(res, err)
 	}
 

--- a/server/service.go
+++ b/server/service.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
-	"sync"
 	"unicode"
 	"unicode/utf8"
 
@@ -41,18 +40,15 @@ var typeOfError = reflect.TypeFor[error]()
 var typeOfContext = reflect.TypeFor[context.Context]()
 
 type methodType struct {
-	sync.Mutex // protects counters
-	method     reflect.Method
-	ArgType    reflect.Type
-	ReplyType  reflect.Type
-	// numCalls   uint
+	method    reflect.Method
+	ArgType   reflect.Type
+	ReplyType reflect.Type
 }
 
 type functionType struct {
-	sync.Mutex // protects counters
-	fn         reflect.Value
-	ArgType    reflect.Type
-	ReplyType  reflect.Type
+	fn        reflect.Value
+	ArgType   reflect.Type
+	ReplyType reflect.Type
 }
 
 type service struct {


### PR DESCRIPTION
## Summary

Two performance fixes surfaced by a concurrency + allocation review of the recently-split `client`/`server` code.

### 1. `getCachedClient` no longer holds `c.mu` across the dial (main fix)

`getCachedClient` held `c.mu` across `generateClient → client.Connect` (a blocking TCP dial). `singleflight` dedups concurrent dials to the *same* key, but the outer `c.mu` serialized **all** callers of the xClient behind one slow/hanging dial — a single unstable server could stall selects for every other server key.

Split into:
- **fast path**: cache lookup under `c.mu`, return on hit and unlock;
- **slow path**: dial outside `c.mu`, inside `singleflight`, re-checking the cache (another goroutine may have cached between our unlock and entering singleflight) and taking `c.mu` only to insert.

`DoClientConnected` still fires exactly once per newly created connection via a `created` flag set only by the dialing goroutine.

### 2. Server object-pool Get/Put balance + dead mutex

- `handleRequest`/`handleRequestForFunction` fetched `argv` from the object pool but leaked it on the nil-codec and Decode-error paths; now `Put` it back before returning the error so the pool doesn't degrade to always allocating.
- Removed the unused embedded `sync.Mutex` from `methodType`/`functionType` (guarded a `numCalls` counter removed long ago; never locked; pollutes the type method set).

## Testing

- `TestGetCachedClientDialDoesNotBlockOtherKeys` — fails (2s timeout) against the old locked version, passes with the fix; stable under `-race -count=3`.
- New `BenchmarkServerHandleRequest` (`ReportAllocs`) anchors the per-request dispatch path (server/ had no hot-path benchmark). Baseline ~811 ns/op, 809 B/op, 14 allocs/op.
- Full `client` + `server` suites pass under `-race`, excluding two `*Pool_SetPlugins_Concurrent` races that pre-exist on master and are unrelated to this change.

## Not included (flagged for follow-up)

- Per-request `make(map[string]string)` for `resMetadata` in `processOneRequest` (allocated even when unused) — needs a benchmark and downstream `ResMetaDataKey` audit.
- Client-side `protocol.NewMessage()` per send/receive — pooling needs message-lifetime guarantees.