### PR TITLE
fix(protocol): cap decompressed payload size to prevent gzip bombs (#942)

### DIFF
--- a/protocol/compressor.go
+++ b/protocol/compressor.go
@@ -14,6 +14,14 @@ type Compressor interface {
 	Unzip([]byte) ([]byte, error)
 }
 
+// LimitedUnzipper is an optional interface a Compressor can implement to cap
+// the size of decompressed data, guarding against decompression-bomb attacks.
+// If a compressor implements it, Message.Decode uses it when
+// MaxDecompressedSize is set. maxSize <= 0 means no limit.
+type LimitedUnzipper interface {
+	UnzipLimited(data []byte, maxSize int64) ([]byte, error)
+}
+
 // GzipCompressor implements gzip compressor.
 type GzipCompressor struct {
 }
@@ -24,6 +32,10 @@ func (c GzipCompressor) Zip(data []byte) ([]byte, error) {
 
 func (c GzipCompressor) Unzip(data []byte) ([]byte, error) {
 	return util.Unzip(data)
+}
+
+func (c GzipCompressor) UnzipLimited(data []byte, maxSize int64) ([]byte, error) {
+	return util.UnzipLimited(data, maxSize)
 }
 
 type RawDataCompressor struct {
@@ -62,15 +74,26 @@ func (c *SnappyCompressor) Zip(data []byte) ([]byte, error) {
 }
 
 func (c *SnappyCompressor) Unzip(data []byte) ([]byte, error) {
+	return c.UnzipLimited(data, 0)
+}
+
+func (c *SnappyCompressor) UnzipLimited(data []byte, maxSize int64) ([]byte, error) {
 	if len(data) == 0 {
 		return data, nil
 	}
 
 	reader := snappy.NewReader(bytes.NewReader(data))
-	out, err := io.ReadAll(reader)
+	if maxSize <= 0 {
+		return io.ReadAll(reader)
+	}
+
+	limited := io.LimitReader(reader, maxSize+1)
+	out, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, err
 	}
-
-	return out, err
+	if int64(len(out)) > maxSize {
+		return nil, util.ErrDecompressedSizeTooLarge
+	}
+	return out, nil
 }

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -25,6 +25,15 @@ var Compressors = map[CompressType]Compressor{
 // It is used to validate when read messages from io.Reader.
 var MaxMessageLength = 0
 
+// MaxDecompressedLength is the max length (in bytes) of the decompressed
+// payload of a message. Default is 0 that means no limit.
+//
+// It guards against decompression-bomb attacks: a small compressed payload
+// (bounded by MaxMessageLength) can otherwise expand to gigabytes of memory
+// during Decode, before authentication runs. Servers that accept traffic from
+// untrusted peers should set this to a sane value.
+var MaxDecompressedLength int64 = 0
+
 const (
 	magicNumber byte = 0x08
 )
@@ -500,7 +509,15 @@ func (m *Message) Decode(r io.Reader) error {
 		if compressor == nil {
 			return ErrUnsupportedCompressor
 		}
-		m.Payload, err = compressor.Unzip(m.Payload)
+		if MaxDecompressedLength > 0 {
+			if lu, ok := compressor.(LimitedUnzipper); ok {
+				m.Payload, err = lu.UnzipLimited(m.Payload, MaxDecompressedLength)
+			} else {
+				m.Payload, err = compressor.Unzip(m.Payload)
+			}
+		} else {
+			m.Payload, err = compressor.Unzip(m.Payload)
+		}
 		if err != nil {
 			return err
 		}

--- a/protocol/message_test.go
+++ b/protocol/message_test.go
@@ -58,3 +58,44 @@ func TestMessage(t *testing.T) {
 		t.Errorf("got wrong payload: %v", string(res.Payload))
 	}
 }
+
+// TestDecodeDecompressBomb verifies that Decode caps the decompressed payload
+// size when MaxDecompressedLength is set, guarding against decompression-bomb
+// attacks (see issue #942).
+func TestDecodeDecompressBomb(t *testing.T) {
+	req := NewMessage()
+	req.SetVersion(0)
+	req.SetMessageType(Request)
+	req.SetCompressType(Gzip)
+	req.SetSerializeType(SerializeNone)
+	req.ServicePath = "Arith"
+	req.ServiceMethod = "Add"
+
+	// A small compressed payload that expands to 1 MiB.
+	req.Payload = bytes.Repeat([]byte("A"), 1<<20)
+
+	var buf bytes.Buffer
+	if _, err := req.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	wire := buf.Bytes()
+
+	// With the cap set below the decompressed size, Decode must reject it.
+	old := MaxDecompressedLength
+	MaxDecompressedLength = 1024
+	defer func() { MaxDecompressedLength = old }()
+
+	if _, err := Read(bytes.NewReader(wire)); err == nil {
+		t.Fatal("expected Decode to reject the decompression bomb, got nil error")
+	}
+
+	// With no cap, the same message decodes fine.
+	MaxDecompressedLength = 0
+	res, err := Read(bytes.NewReader(wire))
+	if err != nil {
+		t.Fatalf("unexpected error without cap: %v", err)
+	}
+	if len(res.Payload) != 1<<20 {
+		t.Fatalf("expected 1 MiB payload, got %d bytes", len(res.Payload))
+	}
+}

--- a/server/option.go
+++ b/server/option.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/alitto/pond"
+	"github.com/smallnest/rpcx/protocol"
 )
 
 // OptionFn configures options of server.
@@ -58,5 +59,23 @@ func WithCustomPool(pool WorkerPool) OptionFn {
 func WithAsyncWrite() OptionFn {
 	return func(s *Server) {
 		s.AsyncWrite = true
+	}
+}
+
+// WithMaxMessageLength caps the wire (compressed) length of an incoming
+// message. It sets protocol.MaxMessageLength. A value <= 0 means no limit.
+func WithMaxMessageLength(maxLen int) OptionFn {
+	return func(s *Server) {
+		protocol.MaxMessageLength = maxLen
+	}
+}
+
+// WithMaxDecompressedLength caps the size (in bytes) of a message payload
+// after decompression. It sets protocol.MaxDecompressedLength, guarding
+// against decompression-bomb attacks where a small compressed payload expands
+// to gigabytes of memory during decode. A value <= 0 means no limit.
+func WithMaxDecompressedLength(maxLen int64) OptionFn {
+	return func(s *Server) {
+		protocol.MaxDecompressedLength = maxLen
 	}
 }

--- a/util/compress.go
+++ b/util/compress.go
@@ -3,9 +3,14 @@ package util
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"io"
 	"sync"
 )
+
+// ErrDecompressedSizeTooLarge is returned when the decompressed data exceeds
+// the configured maximum size. It guards against decompression-bomb attacks.
+var ErrDecompressedSizeTooLarge = errors.New("decompressed size exceeds the maximum allowed size")
 
 var (
 	spWriter sync.Pool
@@ -14,19 +19,35 @@ var (
 )
 
 func init() {
-	spWriter = sync.Pool{New: func() interface{} {
+	spWriter = sync.Pool{New: func() any {
 		return gzip.NewWriter(nil)
 	}}
-	spReader = sync.Pool{New: func() interface{} {
+	spReader = sync.Pool{New: func() any {
 		return new(gzip.Reader)
 	}}
-	spBuffer = sync.Pool{New: func() interface{} {
+	spBuffer = sync.Pool{New: func() any {
 		return bytes.NewBuffer(nil)
 	}}
 }
 
-// Unzip unzips data.
+// Unzip unzips data. If MaxDecompressedSize (see below) is set to a positive
+// value, the decompressed size is capped to guard against decompression bombs.
 func Unzip(data []byte) ([]byte, error) {
+	return UnzipLimited(data, MaxDecompressedSize)
+}
+
+// MaxDecompressedSize is the default maximum allowed size (in bytes) of
+// decompressed data used by Unzip. A value <= 0 means no limit.
+//
+// It protects against decompression-bomb attacks where a small compressed
+// payload expands to a huge amount of memory. Callers that read from
+// untrusted peers should set this to a sane value.
+var MaxDecompressedSize int64 = 0
+
+// UnzipLimited unzips data, capping the decompressed size to maxSize bytes.
+// A maxSize <= 0 means no limit. It returns ErrDecompressedSizeTooLarge if the
+// decompressed data would exceed maxSize.
+func UnzipLimited(data []byte, maxSize int64) ([]byte, error) {
 	buf := bytes.NewBuffer(data)
 
 	gr := spReader.Get().(*gzip.Reader)
@@ -39,11 +60,21 @@ func Unzip(data []byte) ([]byte, error) {
 	}
 	defer gr.Close()
 
-	data, err = io.ReadAll(gr)
+	if maxSize <= 0 {
+		return io.ReadAll(gr)
+	}
+
+	// Read at most maxSize+1 bytes so we can detect an overflow without
+	// allocating the entire oversized payload.
+	limited := io.LimitReader(gr, maxSize+1)
+	out, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, err
 	}
-	return data, err
+	if int64(len(out)) > maxSize {
+		return nil, ErrDecompressedSizeTooLarge
+	}
+	return out, nil
 }
 
 // Zip zips data.

--- a/util/compress_test.go
+++ b/util/compress_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"io"
 	"testing"
 )
@@ -54,6 +55,42 @@ func BenchmarkUnzip(b *testing.B) {
 			_ = s2
 		}
 	})
+}
+
+func TestUnzipLimited(t *testing.T) {
+	// Build a highly compressible payload that expands well beyond the cap.
+	orig := bytes.Repeat([]byte("A"), 1<<20) // 1 MiB of 'A'
+	zipped, err := Zip(orig)
+	if err != nil {
+		t.Fatalf("failed to zip: %v", err)
+	}
+	if len(zipped) >= len(orig) {
+		t.Fatalf("expected zipped data to be much smaller, got %d >= %d", len(zipped), len(orig))
+	}
+
+	// No limit: full payload is returned.
+	out, err := UnzipLimited(zipped, 0)
+	if err != nil {
+		t.Fatalf("unexpected error with no limit: %v", err)
+	}
+	if len(out) != len(orig) {
+		t.Fatalf("expected %d bytes, got %d", len(orig), len(out))
+	}
+
+	// At the cap: allowed.
+	out, err = UnzipLimited(zipped, int64(len(orig)))
+	if err != nil {
+		t.Fatalf("unexpected error at exact limit: %v", err)
+	}
+	if len(out) != len(orig) {
+		t.Fatalf("expected %d bytes, got %d", len(orig), len(out))
+	}
+
+	// Over the cap: rejected.
+	_, err = UnzipLimited(zipped, int64(len(orig))-1)
+	if !errors.Is(err, ErrDecompressedSizeTooLarge) {
+		t.Fatalf("expected ErrDecompressedSizeTooLarge, got %v", err)
+	}
 }
 
 func oldUnzip(data []byte) ([]byte, error) {


### PR DESCRIPTION
## Summary

Fixes #942 — an unauthenticated gzip decompression bomb in the rpcx wire protocol.

`Message.Decode` decompressed gzip (and snappy) payloads with `io.ReadAll` and **no cap on output size**, before service lookup or auth. `MaxMessageLength` only bounds the *compressed* wire length, so a small frame (<2MB) could expand to gigabytes and OOM the server fully pre-authentication.

## Changes

- **util/compress.go**: add `UnzipLimited(data, maxSize)` using `io.LimitReader(gr, maxSize+1)` to detect overflow without allocating the oversized payload; returns new `ErrDecompressedSizeTooLarge`. `Unzip` now honors package-level `MaxDecompressedSize`.
- **protocol/compressor.go**: add optional `LimitedUnzipper` interface, implemented on `GzipCompressor` and `SnappyCompressor` (snappy had the same unbounded `io.ReadAll`).
- **protocol/message.go**: add `MaxDecompressedLength`; `Decode` caps decompression via `LimitedUnzipper` when set — bounded **before** service lookup and auth.
- **server/option.go**: add `WithMaxDecompressedLength(int64)` and `WithMaxMessageLength(int)` options.

## Backward compatibility

Caps default to `0` (unlimited), so behavior is unchanged unless configured. Servers accepting untrusted traffic should set one, e.g.:

```go
server.NewServer(server.WithMaxDecompressedLength(64 << 20))
```

## Tests

- `util.TestUnzipLimited` — payload over/at/under the cap.
- `protocol.TestDecodeDecompressBomb` — a small compressed frame expanding to 1 MiB is rejected when the cap is set, decodes fine when unlimited.

All of `./util`, `./protocol`, `./server` build, vet, and test green.